### PR TITLE
feat: add packageManager field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ethniafrique-atlas",
   "private": true,
   "version": "1.1.0",
+  "packageManager": "npm@10.8.2",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Pins the package manager to `npm@10.8.2` (the version on the ubuntu-latest runner) so Ferry dev agents don't probe pnpm/yarn before falling back to npm.

Closes #69

Generated with [Claude Code](https://claude.ai/code)