### PR TITLE
feat: add pre_agent_command to run npm ci before Ferry agent starts

### DIFF
--- a/ferry.config.json
+++ b/ferry.config.json
@@ -5,5 +5,8 @@
   },
   "limits": {
     "max_tokens_per_run": 1000000
+  },
+  "setup": {
+    "pre_agent_command": "npm ci"
   }
 }


### PR DESCRIPTION
Adds `setup.pre_agent_command` to `ferry.config.json` so that `npm ci` runs before the Ferry dev agent starts, preventing mid-session installs that consume token budget.

Closes #71

Generated with [Claude Code](https://claude.ai/code)