### PR TITLE
chore(ferry): raise max_tokens_per_run to 5000000 on main

### DIFF
--- a/ferry.config.json
+++ b/ferry.config.json
@@ -4,7 +4,7 @@
     "target_branch": "recette"
   },
   "limits": {
-    "max_tokens_per_run": 1000000
+    "max_tokens_per_run": 5000000
   },
   "setup": {
     "pre_agent_command": "npm ci"


### PR DESCRIPTION
## Summary
- Bump `ferry.config.json` `limits.max_tokens_per_run` from `1000000` → `5000000` on `main`.
- `recette` already runs at `5000000`; Ferry loads config from the default branch (`main`), so the cap was effectively staying at the lower value regardless of `recette`.

## Why
Ferry's `actions/checkout` reads `ferry.config.json` from the default branch. Until `main` carries the bump, the per-run token cap stays at `1000000` for all consumers — the higher value on `recette` has no effect.

## Test plan
- [ ] Confirm next Ferry run picks up `max_tokens_per_run: 5000000`