### PR TITLE
ETNI-24: Module #0 N+1 batch helpers

### DIFF
--- a/src/lib/supabase/queries/afrik/__tests__/module-zero-batch.test.ts
+++ b/src/lib/supabase/queries/afrik/__tests__/module-zero-batch.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Tests for Module #0 N+1 batch helpers (ETNI-24).
+ *
+ * Each helper MUST perform exactly ONE Supabase query for N input IDs,
+ * regardless of N. The Map<peopleId, T> shape ensures O(1) lookup by caller.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../server", () => ({
+  createServerClient: vi.fn(),
+}));
+
+vi.mock("@/lib/api/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import {
+  getSourcesMap,
+  getConfidenceMap,
+  getFlagsSummaryMap,
+  getLatestRevisionMap,
+} from "../module-zero-batch";
+import { createServerClient } from "../../../server";
+import { logger } from "@/lib/api/logger";
+
+interface QueryResult {
+  data: unknown[] | null;
+  error: { message: string } | null;
+}
+
+/**
+ * Build a Supabase mock that records every `from()` call and resolves
+ * the terminal `.in()` (or `.order().in()`) with the provided result.
+ */
+function buildSupabaseMock(result: QueryResult) {
+  const fromSpy = vi.fn();
+  const selectSpy = vi.fn();
+  const inSpy = vi.fn();
+  const orderSpy = vi.fn();
+  const eqSpy = vi.fn();
+
+  // .in() is the terminal call returning the promise.
+  inSpy.mockResolvedValue(result);
+
+  const chain = {
+    select: selectSpy,
+    in: inSpy,
+    order: orderSpy,
+    eq: eqSpy,
+  };
+
+  selectSpy.mockReturnValue(chain);
+  orderSpy.mockReturnValue(chain);
+  eqSpy.mockReturnValue(chain);
+
+  fromSpy.mockReturnValue(chain);
+
+  const client = { from: fromSpy };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (createServerClient as any).mockReturnValue(client);
+
+  return { fromSpy, selectSpy, inSpy, orderSpy, eqSpy };
+}
+
+function makeIds(n: number): string[] {
+  return Array.from(
+    { length: n },
+    (_, i) => `PPL_TEST_${String(i).padStart(3, "0")}`
+  );
+}
+
+describe("module-zero-batch helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getSourcesMap", () => {
+    it("returns an empty Map when peopleIds is empty (no query)", async () => {
+      const { fromSpy } = buildSupabaseMock({ data: [], error: null });
+
+      const result = await getSourcesMap([]);
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+      expect(fromSpy).not.toHaveBeenCalled();
+    });
+
+    it("performs exactly ONE query for 50 IDs", async () => {
+      const ids = makeIds(50);
+      const { fromSpy, inSpy } = buildSupabaseMock({ data: [], error: null });
+
+      await getSourcesMap(ids);
+
+      expect(fromSpy).toHaveBeenCalledTimes(1);
+      expect(inSpy).toHaveBeenCalledTimes(1);
+      expect(inSpy).toHaveBeenCalledWith("entity_id", ids);
+    });
+
+    it("groups sources by peopleId in the returned Map", async () => {
+      const ids = ["PPL_A", "PPL_B"];
+      buildSupabaseMock({
+        data: [
+          {
+            entity_id: "PPL_A",
+            sources: {
+              id: "src-1",
+              title: "Source 1",
+              url: "https://x",
+              type: "academic",
+            },
+          },
+          {
+            entity_id: "PPL_A",
+            sources: { id: "src-2", title: "Source 2", url: null, type: null },
+          },
+          {
+            entity_id: "PPL_B",
+            sources: {
+              id: "src-3",
+              title: "Source 3",
+              url: "https://y",
+              type: "ngo",
+            },
+          },
+        ],
+        error: null,
+      });
+
+      const result = await getSourcesMap(ids);
+
+      expect(result.get("PPL_A")).toHaveLength(2);
+      expect(result.get("PPL_B")).toHaveLength(1);
+      expect(result.get("PPL_A")?.[0].id).toBe("src-1");
+    });
+
+    it("logs via logger.error and returns empty Map on query error", async () => {
+      buildSupabaseMock({ data: null, error: { message: "boom" } });
+
+      const result = await getSourcesMap(["PPL_A"]);
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(
+        (logger.error as unknown as { mock: { calls: unknown[][] } }).mock
+          .calls[0][0]
+      ).toContain("module-zero-batch.getSourcesMap");
+    });
+  });
+
+  describe("getConfidenceMap", () => {
+    it("returns an empty Map when peopleIds is empty (no query)", async () => {
+      const { fromSpy } = buildSupabaseMock({ data: [], error: null });
+
+      const result = await getConfidenceMap([]);
+
+      expect(result.size).toBe(0);
+      expect(fromSpy).not.toHaveBeenCalled();
+    });
+
+    it("performs exactly ONE query for 50 IDs", async () => {
+      const ids = makeIds(50);
+      const { fromSpy, inSpy } = buildSupabaseMock({ data: [], error: null });
+
+      await getConfidenceMap(ids);
+
+      expect(fromSpy).toHaveBeenCalledTimes(1);
+      expect(inSpy).toHaveBeenCalledTimes(1);
+      expect(inSpy).toHaveBeenCalledWith("entity_id", ids);
+    });
+
+    it("maps a single confidence score per peopleId", async () => {
+      buildSupabaseMock({
+        data: [
+          {
+            entity_id: "PPL_A",
+            confidence_scores: {
+              id: "cs-1",
+              score: 0.85,
+              methodology: "weighted-avg",
+            },
+          },
+          {
+            entity_id: "PPL_B",
+            confidence_scores: {
+              id: "cs-2",
+              score: 0.6,
+              methodology: "manual",
+            },
+          },
+        ],
+        error: null,
+      });
+
+      const result = await getConfidenceMap(["PPL_A", "PPL_B"]);
+
+      expect(result.get("PPL_A")?.score).toBe(0.85);
+      expect(result.get("PPL_B")?.methodology).toBe("manual");
+    });
+
+    it("logs via logger.error and returns empty Map on query error", async () => {
+      buildSupabaseMock({ data: null, error: { message: "boom" } });
+
+      const result = await getConfidenceMap(["PPL_A"]);
+
+      expect(result.size).toBe(0);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(
+        (logger.error as unknown as { mock: { calls: unknown[][] } }).mock
+          .calls[0][0]
+      ).toContain("module-zero-batch.getConfidenceMap");
+    });
+  });
+
+  describe("getFlagsSummaryMap", () => {
+    it("returns an empty Map when peopleIds is empty (no query)", async () => {
+      const { fromSpy } = buildSupabaseMock({ data: [], error: null });
+
+      const result = await getFlagsSummaryMap([]);
+
+      expect(result.size).toBe(0);
+      expect(fromSpy).not.toHaveBeenCalled();
+    });
+
+    it("performs exactly ONE query for 50 IDs", async () => {
+      const ids = makeIds(50);
+      const { fromSpy, inSpy } = buildSupabaseMock({ data: [], error: null });
+
+      await getFlagsSummaryMap(ids);
+
+      expect(fromSpy).toHaveBeenCalledTimes(1);
+      expect(inSpy).toHaveBeenCalledTimes(1);
+      expect(inSpy).toHaveBeenCalledWith("entity_id", ids);
+    });
+
+    it("returns openCount and totalCount per peopleId", async () => {
+      buildSupabaseMock({
+        data: [
+          { entity_id: "PPL_A", status: "pending" },
+          { entity_id: "PPL_A", status: "pending" },
+          { entity_id: "PPL_A", status: "resolved" },
+          { entity_id: "PPL_B", status: "reviewed" },
+          { entity_id: "PPL_B", status: "dismissed" },
+        ],
+        error: null,
+      });
+
+      const result = await getFlagsSummaryMap(["PPL_A", "PPL_B"]);
+
+      expect(result.get("PPL_A")).toEqual({ openCount: 2, totalCount: 3 });
+      // 'reviewed' is considered open (not resolved/dismissed); 'dismissed' is closed.
+      expect(result.get("PPL_B")).toEqual({ openCount: 1, totalCount: 2 });
+    });
+
+    it("logs via logger.error and returns empty Map on query error", async () => {
+      buildSupabaseMock({ data: null, error: { message: "boom" } });
+
+      const result = await getFlagsSummaryMap(["PPL_A"]);
+
+      expect(result.size).toBe(0);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(
+        (logger.error as unknown as { mock: { calls: unknown[][] } }).mock
+          .calls[0][0]
+      ).toContain("module-zero-batch.getFlagsSummaryMap");
+    });
+  });
+
+  describe("getLatestRevisionMap", () => {
+    it("returns an empty Map when peopleIds is empty (no query)", async () => {
+      const { fromSpy } = buildSupabaseMock({ data: [], error: null });
+
+      const result = await getLatestRevisionMap([]);
+
+      expect(result.size).toBe(0);
+      expect(fromSpy).not.toHaveBeenCalled();
+    });
+
+    it("performs exactly ONE query for 50 IDs", async () => {
+      const ids = makeIds(50);
+      const { fromSpy, inSpy } = buildSupabaseMock({ data: [], error: null });
+
+      await getLatestRevisionMap(ids);
+
+      expect(fromSpy).toHaveBeenCalledTimes(1);
+      expect(inSpy).toHaveBeenCalledTimes(1);
+      expect(inSpy).toHaveBeenCalledWith("entity_id", ids);
+    });
+
+    it("keeps only the latest revision per peopleId", async () => {
+      // DB returns rows ordered by created_at DESC, so the first row per
+      // entity_id is the latest. We assert the helper preserves that.
+      buildSupabaseMock({
+        data: [
+          {
+            id: "rev-2",
+            entity_id: "PPL_A",
+            field_path: "content.name",
+            new_value: "Latest",
+            changed_by: "user-1",
+            change_reason: "fix typo",
+            created_at: "2026-05-14T10:00:00Z",
+          },
+          {
+            id: "rev-1",
+            entity_id: "PPL_A",
+            field_path: "content.name",
+            new_value: "Older",
+            changed_by: "user-2",
+            change_reason: "initial",
+            created_at: "2026-05-13T10:00:00Z",
+          },
+          {
+            id: "rev-3",
+            entity_id: "PPL_B",
+            field_path: "content.history",
+            new_value: "Foo",
+            changed_by: "user-1",
+            change_reason: null,
+            created_at: "2026-05-12T10:00:00Z",
+          },
+        ],
+        error: null,
+      });
+
+      const result = await getLatestRevisionMap(["PPL_A", "PPL_B"]);
+
+      expect(result.get("PPL_A")?.id).toBe("rev-2");
+      expect(result.get("PPL_B")?.id).toBe("rev-3");
+      expect(result.size).toBe(2);
+    });
+
+    it("logs via logger.error and returns empty Map on query error", async () => {
+      buildSupabaseMock({ data: null, error: { message: "boom" } });
+
+      const result = await getLatestRevisionMap(["PPL_A"]);
+
+      expect(result.size).toBe(0);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(
+        (logger.error as unknown as { mock: { calls: unknown[][] } }).mock
+          .calls[0][0]
+      ).toContain("module-zero-batch.getLatestRevisionMap");
+    });
+  });
+});

--- a/src/lib/supabase/queries/afrik/__tests__/module-zero-batch.test.ts
+++ b/src/lib/supabase/queries/afrik/__tests__/module-zero-batch.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for Module #0 N+1 batch helpers (ETNI-24).
  *
- * Each helper MUST perform exactly ONE Supabase query for N input IDs,
- * regardless of N. The Map<peopleId, T> shape ensures O(1) lookup by caller.
+ * Each helper batches Supabase queries into a constant number of round-trips
+ * for N input IDs (with chunked `.in()` only when N exceeds CHUNK_SIZE).
+ * The Map<peopleId, T> shape ensures O(1) lookup by caller.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -36,17 +37,23 @@ interface QueryResult {
 
 /**
  * Build a Supabase mock that records every `from()` call and resolves
- * the terminal `.in()` (or `.order().in()`) with the provided result.
+ * the terminal `.in()` call. The terminal `.in()` returns the next result
+ * from the provided queue (one per `from()` invocation). The same chain is
+ * reused for all .from() calls — `.select`, `.eq`, `.order` are pass-through.
  */
-function buildSupabaseMock(result: QueryResult) {
+function buildSupabaseMock(results: QueryResult | QueryResult[]) {
+  const queue = Array.isArray(results) ? [...results] : [results];
+
   const fromSpy = vi.fn();
   const selectSpy = vi.fn();
   const inSpy = vi.fn();
   const orderSpy = vi.fn();
   const eqSpy = vi.fn();
 
-  // .in() is the terminal call returning the promise.
-  inSpy.mockResolvedValue(result);
+  inSpy.mockImplementation(() => {
+    const next = queue.shift();
+    return Promise.resolve(next || { data: [], error: null });
+  });
 
   const chain = {
     select: selectSpy,
@@ -71,7 +78,7 @@ function buildSupabaseMock(result: QueryResult) {
 function makeIds(n: number): string[] {
   return Array.from(
     { length: n },
-    (_, i) => `PPL_TEST_${String(i).padStart(3, "0")}`
+    (_, i) => `PPL_TEST_${String(i).padStart(4, "0")}`
   );
 }
 
@@ -91,52 +98,105 @@ describe("module-zero-batch helpers", () => {
       expect(fromSpy).not.toHaveBeenCalled();
     });
 
-    it("performs exactly ONE query for 50 IDs", async () => {
+    it("uses two queries (assertions, sources) for non-empty input", async () => {
       const ids = makeIds(50);
-      const { fromSpy, inSpy } = buildSupabaseMock({ data: [], error: null });
+      const { fromSpy, inSpy } = buildSupabaseMock([
+        {
+          data: [
+            { entity_id: "PPL_TEST_0000", source_ids: ["sid-1"] },
+            { entity_id: "PPL_TEST_0001", source_ids: ["sid-2"] },
+          ],
+          error: null,
+        },
+        {
+          data: [
+            { id: "sid-1", title: "S1", url: null, tier: "academic" },
+            { id: "sid-2", title: "S2", url: "https://y", tier: "ngo" },
+          ],
+          error: null,
+        },
+      ]);
 
       await getSourcesMap(ids);
 
-      expect(fromSpy).toHaveBeenCalledTimes(1);
-      expect(inSpy).toHaveBeenCalledTimes(1);
-      expect(inSpy).toHaveBeenCalledWith("entity_id", ids);
+      expect(fromSpy).toHaveBeenCalledTimes(2);
+      expect(fromSpy).toHaveBeenNthCalledWith(1, "assertions");
+      expect(fromSpy).toHaveBeenNthCalledWith(2, "sources");
+      expect(inSpy).toHaveBeenNthCalledWith(1, "entity_id", ids);
     });
 
     it("groups sources by peopleId in the returned Map", async () => {
-      const ids = ["PPL_A", "PPL_B"];
-      buildSupabaseMock({
-        data: [
-          {
-            entity_id: "PPL_A",
-            sources: {
+      buildSupabaseMock([
+        {
+          data: [
+            { entity_id: "PPL_A", source_ids: ["src-1", "src-2"] },
+            { entity_id: "PPL_B", source_ids: ["src-3"] },
+          ],
+          error: null,
+        },
+        {
+          data: [
+            {
               id: "src-1",
               title: "Source 1",
               url: "https://x",
-              type: "academic",
+              tier: "academic",
             },
-          },
-          {
-            entity_id: "PPL_A",
-            sources: { id: "src-2", title: "Source 2", url: null, type: null },
-          },
-          {
-            entity_id: "PPL_B",
-            sources: {
-              id: "src-3",
-              title: "Source 3",
-              url: "https://y",
-              type: "ngo",
-            },
-          },
-        ],
-        error: null,
-      });
+            { id: "src-2", title: "Source 2", url: null, tier: null },
+            { id: "src-3", title: "Source 3", url: "https://y", tier: "ngo" },
+          ],
+          error: null,
+        },
+      ]);
 
-      const result = await getSourcesMap(ids);
+      const result = await getSourcesMap(["PPL_A", "PPL_B"]);
 
       expect(result.get("PPL_A")).toHaveLength(2);
       expect(result.get("PPL_B")).toHaveLength(1);
       expect(result.get("PPL_A")?.[0].id).toBe("src-1");
+      expect(result.get("PPL_A")?.[0].tier).toBe("academic");
+    });
+
+    it("skips assertions with empty/null source_ids", async () => {
+      buildSupabaseMock([
+        {
+          data: [
+            { entity_id: "PPL_A", source_ids: ["src-1"] },
+            { entity_id: "PPL_B", source_ids: null },
+            { entity_id: "PPL_C", source_ids: [] },
+          ],
+          error: null,
+        },
+        {
+          data: [{ id: "src-1", title: "S1", url: null, tier: null }],
+          error: null,
+        },
+      ]);
+
+      const result = await getSourcesMap(["PPL_A", "PPL_B", "PPL_C"]);
+
+      expect(result.get("PPL_A")).toHaveLength(1);
+      expect(result.has("PPL_B")).toBe(false);
+      expect(result.has("PPL_C")).toBe(false);
+    });
+
+    it("chunks .in() into batches of 500 when ids.length > 500", async () => {
+      const ids = makeIds(1200);
+      // 3 assertion chunks (500 + 500 + 200), then 1 sources lookup.
+      const { fromSpy, inSpy } = buildSupabaseMock([
+        { data: [], error: null },
+        { data: [], error: null },
+        { data: [], error: null },
+      ]);
+
+      await getSourcesMap(ids);
+
+      // 3 chunked assertions calls + 0 sources calls (no source ids).
+      expect(fromSpy).toHaveBeenCalledTimes(3);
+      expect(inSpy).toHaveBeenCalledTimes(3);
+      expect((inSpy.mock.calls[0][1] as string[]).length).toBe(500);
+      expect((inSpy.mock.calls[1][1] as string[]).length).toBe(500);
+      expect((inSpy.mock.calls[2][1] as string[]).length).toBe(200);
     });
 
     it("logs via logger.error and returns empty Map on query error", async () => {
@@ -164,13 +224,18 @@ describe("module-zero-batch helpers", () => {
       expect(fromSpy).not.toHaveBeenCalled();
     });
 
-    it("performs exactly ONE query for 50 IDs", async () => {
+    it("queries confidence_scores directly with entity_type filter", async () => {
       const ids = makeIds(50);
-      const { fromSpy, inSpy } = buildSupabaseMock({ data: [], error: null });
+      const { fromSpy, inSpy, eqSpy } = buildSupabaseMock({
+        data: [],
+        error: null,
+      });
 
       await getConfidenceMap(ids);
 
       expect(fromSpy).toHaveBeenCalledTimes(1);
+      expect(fromSpy).toHaveBeenCalledWith("confidence_scores");
+      expect(eqSpy).toHaveBeenCalledWith("entity_type", "people");
       expect(inSpy).toHaveBeenCalledTimes(1);
       expect(inSpy).toHaveBeenCalledWith("entity_id", ids);
     });
@@ -180,19 +245,21 @@ describe("module-zero-batch helpers", () => {
         data: [
           {
             entity_id: "PPL_A",
-            confidence_scores: {
-              id: "cs-1",
-              score: 0.85,
-              methodology: "weighted-avg",
-            },
+            score: 0.85,
+            source_count: 4,
+            avg_source_quality: 0.9,
+            last_human_audit_at: "2026-05-01T00:00:00Z",
+            open_flag_count: 0,
+            recomputed_at: "2026-05-10T00:00:00Z",
           },
           {
             entity_id: "PPL_B",
-            confidence_scores: {
-              id: "cs-2",
-              score: 0.6,
-              methodology: "manual",
-            },
+            score: 0.6,
+            source_count: 2,
+            avg_source_quality: 0.5,
+            last_human_audit_at: null,
+            open_flag_count: 1,
+            recomputed_at: "2026-05-09T00:00:00Z",
           },
         ],
         error: null,
@@ -201,7 +268,24 @@ describe("module-zero-batch helpers", () => {
       const result = await getConfidenceMap(["PPL_A", "PPL_B"]);
 
       expect(result.get("PPL_A")?.score).toBe(0.85);
-      expect(result.get("PPL_B")?.methodology).toBe("manual");
+      expect(result.get("PPL_A")?.sourceCount).toBe(4);
+      expect(result.get("PPL_B")?.openFlagCount).toBe(1);
+    });
+
+    it("chunks .in() into batches of 500 when ids.length > 500", async () => {
+      const ids = makeIds(1100);
+      const { fromSpy, inSpy } = buildSupabaseMock([
+        { data: [], error: null },
+        { data: [], error: null },
+        { data: [], error: null },
+      ]);
+
+      await getConfidenceMap(ids);
+
+      expect(fromSpy).toHaveBeenCalledTimes(3);
+      expect(inSpy).toHaveBeenCalledTimes(3);
+      expect((inSpy.mock.calls[0][1] as string[]).length).toBe(500);
+      expect((inSpy.mock.calls[2][1] as string[]).length).toBe(100);
     });
 
     it("logs via logger.error and returns empty Map on query error", async () => {
@@ -254,8 +338,21 @@ describe("module-zero-batch helpers", () => {
       const result = await getFlagsSummaryMap(["PPL_A", "PPL_B"]);
 
       expect(result.get("PPL_A")).toEqual({ openCount: 2, totalCount: 3 });
-      // 'reviewed' is considered open (not resolved/dismissed); 'dismissed' is closed.
       expect(result.get("PPL_B")).toEqual({ openCount: 1, totalCount: 2 });
+    });
+
+    it("chunks .in() into batches of 500 when ids.length > 500", async () => {
+      const ids = makeIds(1500);
+      const { fromSpy, inSpy } = buildSupabaseMock([
+        { data: [], error: null },
+        { data: [], error: null },
+        { data: [], error: null },
+      ]);
+
+      await getFlagsSummaryMap(ids);
+
+      expect(fromSpy).toHaveBeenCalledTimes(3);
+      expect(inSpy).toHaveBeenCalledTimes(3);
     });
 
     it("logs via logger.error and returns empty Map on query error", async () => {
@@ -294,8 +391,6 @@ describe("module-zero-batch helpers", () => {
     });
 
     it("keeps only the latest revision per peopleId", async () => {
-      // DB returns rows ordered by created_at DESC, so the first row per
-      // entity_id is the latest. We assert the helper preserves that.
       buildSupabaseMock({
         data: [
           {
@@ -334,6 +429,21 @@ describe("module-zero-batch helpers", () => {
       expect(result.get("PPL_A")?.id).toBe("rev-2");
       expect(result.get("PPL_B")?.id).toBe("rev-3");
       expect(result.size).toBe(2);
+    });
+
+    it("chunks .in() into batches of 500 when ids.length > 500", async () => {
+      const ids = makeIds(1000);
+      const { fromSpy, inSpy } = buildSupabaseMock([
+        { data: [], error: null },
+        { data: [], error: null },
+      ]);
+
+      await getLatestRevisionMap(ids);
+
+      expect(fromSpy).toHaveBeenCalledTimes(2);
+      expect(inSpy).toHaveBeenCalledTimes(2);
+      expect((inSpy.mock.calls[0][1] as string[]).length).toBe(500);
+      expect((inSpy.mock.calls[1][1] as string[]).length).toBe(500);
     });
 
     it("logs via logger.error and returns empty Map on query error", async () => {

--- a/src/lib/supabase/queries/afrik/module-zero-batch.ts
+++ b/src/lib/supabase/queries/afrik/module-zero-batch.ts
@@ -3,18 +3,19 @@
  *
  * Public fiche routes need source-transparency data (sources, confidence,
  * flag summary, latest revision) for many peopleIds at once. Naive code
- * issues one query per id (N+1). These helpers each perform exactly ONE
- * Supabase round-trip for N inputs and return `Map<peopleId, T>` for O(1)
- * caller lookups.
+ * issues one query per id (N+1). These helpers batch in single queries
+ * (with safe chunking for very large id sets) and return `Map<peopleId, T>`
+ * for O(1) caller lookups.
  *
- * Schema assumption: the Module #0 tables (sources, assertions,
- * confidence_scores, flags, revisions) follow the 008 layout reconciled by
- * ETNI-22 / migration 014 — every entity row exposes an `entity_id` column
- * referencing the AFRIK people id. If a future migration renames columns,
- * this file is the single place to update.
+ * Schema assumption: the Module #0 tables reflect the post-014 layout:
+ *  - `assertions.source_ids UUID[]` (no FK, no embed possible)
+ *  - `sources.tier` (renamed from `type`)
+ *  - `confidence_scores` is entity-scoped (`entity_type`, `entity_id`)
  *
  * All helpers:
  *  - short-circuit on empty input (no query),
+ *  - chunk `.in(...)` calls when `ids.length` exceeds CHUNK_SIZE to avoid
+ *    Supabase URL-size limits,
  *  - log failures through `@/lib/api/logger` (never `console.*`),
  *  - return an empty Map on error so callers never break the page.
  */
@@ -22,23 +23,21 @@
 import { createServerClient } from "../../server";
 import { logger } from "@/lib/api/logger";
 
-// ---------------------------------------------------------------------------
-// Types — kept local to avoid coupling fiche routes to DB-row shapes. When
-// ETNI-22 lands, these can be promoted to `@/types/afrik` if other modules
-// need them.
-// ---------------------------------------------------------------------------
-
 export interface Source {
   id: string;
   title: string;
   url: string | null;
-  type: string | null;
+  tier: string | null;
 }
 
 export interface ConfidenceScore {
-  id: string;
+  entityId: string;
   score: number;
-  methodology: string | null;
+  sourceCount: number | null;
+  avgSourceQuality: number | null;
+  lastHumanAuditAt: string | null;
+  openFlagCount: number | null;
+  recomputedAt: string | null;
 }
 
 export interface FlagSummary {
@@ -56,14 +55,30 @@ export interface Revision {
   createdAt: string;
 }
 
-// Flag statuses considered "closed" — anything else counts as open.
 const CLOSED_FLAG_STATUSES = new Set(["resolved", "dismissed"]);
+
+const CHUNK_SIZE = 500;
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  if (arr.length <= size) return [arr];
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+  return out;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
 
 /**
  * Sources cited by assertions tied to the given peopleIds.
  *
- * Single query: `assertions` filtered by `entity_id IN (...)`, with the
- * referenced `sources` row embedded via the FK. Grouped client-side.
+ * Two-step fetch (post-014 schema: `assertions.source_ids UUID[]`):
+ *   1) read `entity_id, source_ids` from `assertions`
+ *   2) hydrate `sources` rows for the union of source_ids
+ * Results are grouped client-side into Map<peopleId, Source[]>.
  */
 export async function getSourcesMap(
   peopleIds: string[]
@@ -71,28 +86,64 @@ export async function getSourcesMap(
   if (peopleIds.length === 0) return new Map();
 
   const supabase = createServerClient();
-  const { data, error } = await supabase
-    .from("assertions")
-    .select("entity_id, sources(id, title, url, type)")
-    .in("entity_id", peopleIds);
+  const idChunks = chunk(peopleIds, CHUNK_SIZE);
 
-  if (error) {
-    logger.error("module-zero-batch.getSourcesMap failed", error);
-    return new Map();
+  const assertionRows: Array<{
+    entity_id: string;
+    source_ids: string[] | null;
+  }> = [];
+
+  for (const ids of idChunks) {
+    const { data, error } = await supabase
+      .from("assertions")
+      .select("entity_id, source_ids")
+      .in("entity_id", ids);
+
+    if (error) {
+      logger.error("module-zero-batch.getSourcesMap failed", error);
+      return new Map();
+    }
+    assertionRows.push(
+      ...((data || []) as Array<{
+        entity_id: string;
+        source_ids: string[] | null;
+      }>)
+    );
+  }
+
+  const allSourceIds = uniqueStrings(
+    assertionRows.flatMap((r) => r.source_ids ?? [])
+  );
+
+  const sourcesById = new Map<string, Source>();
+  if (allSourceIds.length > 0) {
+    const sourceIdChunks = chunk(allSourceIds, CHUNK_SIZE);
+    for (const sids of sourceIdChunks) {
+      const { data, error } = await supabase
+        .from("sources")
+        .select("id, title, url, tier")
+        .in("id", sids);
+
+      if (error) {
+        logger.error("module-zero-batch.getSourcesMap failed", error);
+        return new Map();
+      }
+      for (const src of (data || []) as Source[]) {
+        sourcesById.set(src.id, src);
+      }
+    }
   }
 
   const map = new Map<string, Source[]>();
-  for (const row of (data || []) as Array<{
-    entity_id: string;
-    sources: Source | Source[] | null;
-  }>) {
-    if (!row.sources) continue;
-    const sources = Array.isArray(row.sources) ? row.sources : [row.sources];
+  for (const row of assertionRows) {
+    const ids = row.source_ids ?? [];
+    if (ids.length === 0) continue;
     const existing = map.get(row.entity_id) || [];
-    for (const src of sources) {
+    for (const sid of ids) {
+      const src = sourcesById.get(sid);
       if (src) existing.push(src);
     }
-    map.set(row.entity_id, existing);
+    if (existing.length > 0) map.set(row.entity_id, existing);
   }
   return map;
 }
@@ -100,10 +151,8 @@ export async function getSourcesMap(
 /**
  * Latest confidence score per peopleId.
  *
- * Single query: `assertions` filtered by `entity_id IN (...)`, with the
- * latest `confidence_scores` row embedded. If multiple confidence rows exist
- * we keep the first non-null seen per peopleId; callers can fold further if
- * needed (out of scope for this story).
+ * Post-014 schema: `confidence_scores` is entity-scoped. Query directly with
+ * (entity_type='people', entity_id IN (...)). First seen non-null per id wins.
  */
 export async function getConfidenceMap(
   peopleIds: string[]
@@ -111,27 +160,43 @@ export async function getConfidenceMap(
   if (peopleIds.length === 0) return new Map();
 
   const supabase = createServerClient();
-  const { data, error } = await supabase
-    .from("assertions")
-    .select("entity_id, confidence_scores(id, score, methodology)")
-    .in("entity_id", peopleIds);
-
-  if (error) {
-    logger.error("module-zero-batch.getConfidenceMap failed", error);
-    return new Map();
-  }
+  const idChunks = chunk(peopleIds, CHUNK_SIZE);
 
   const map = new Map<string, ConfidenceScore>();
-  for (const row of (data || []) as Array<{
-    entity_id: string;
-    confidence_scores: ConfidenceScore | ConfidenceScore[] | null;
-  }>) {
-    if (map.has(row.entity_id)) continue;
-    if (!row.confidence_scores) continue;
-    const cs = Array.isArray(row.confidence_scores)
-      ? row.confidence_scores[0]
-      : row.confidence_scores;
-    if (cs) map.set(row.entity_id, cs);
+  for (const ids of idChunks) {
+    const { data, error } = await supabase
+      .from("confidence_scores")
+      .select(
+        "entity_id, score, source_count, avg_source_quality, last_human_audit_at, open_flag_count, recomputed_at"
+      )
+      .eq("entity_type", "people")
+      .in("entity_id", ids);
+
+    if (error) {
+      logger.error("module-zero-batch.getConfidenceMap failed", error);
+      return new Map();
+    }
+
+    for (const row of (data || []) as Array<{
+      entity_id: string;
+      score: number;
+      source_count: number | null;
+      avg_source_quality: number | null;
+      last_human_audit_at: string | null;
+      open_flag_count: number | null;
+      recomputed_at: string | null;
+    }>) {
+      if (map.has(row.entity_id)) continue;
+      map.set(row.entity_id, {
+        entityId: row.entity_id,
+        score: row.score,
+        sourceCount: row.source_count,
+        avgSourceQuality: row.avg_source_quality,
+        lastHumanAuditAt: row.last_human_audit_at,
+        openFlagCount: row.open_flag_count,
+        recomputedAt: row.recomputed_at,
+      });
+    }
   }
   return map;
 }
@@ -139,10 +204,6 @@ export async function getConfidenceMap(
 /**
  * Per-peopleId flag summary: total flag count and the subset still "open"
  * (status not in {resolved, dismissed}).
- *
- * Single query: `flags` filtered by `entity_id IN (...)`. Aggregation is
- * cheap in-memory because the result set is bounded by the active flags
- * touching the requested peoples.
  */
 export async function getFlagsSummaryMap(
   peopleIds: string[]
@@ -150,27 +211,34 @@ export async function getFlagsSummaryMap(
   if (peopleIds.length === 0) return new Map();
 
   const supabase = createServerClient();
-  const { data, error } = await supabase
-    .from("flags")
-    .select("entity_id, status")
-    .in("entity_id", peopleIds);
-
-  if (error) {
-    logger.error("module-zero-batch.getFlagsSummaryMap failed", error);
-    return new Map();
-  }
+  const idChunks = chunk(peopleIds, CHUNK_SIZE);
 
   const map = new Map<string, FlagSummary>();
-  for (const row of (data || []) as Array<{
-    entity_id: string;
-    status: string | null;
-  }>) {
-    const existing = map.get(row.entity_id) || { openCount: 0, totalCount: 0 };
-    existing.totalCount += 1;
-    if (!row.status || !CLOSED_FLAG_STATUSES.has(row.status)) {
-      existing.openCount += 1;
+  for (const ids of idChunks) {
+    const { data, error } = await supabase
+      .from("flags")
+      .select("entity_id, status")
+      .in("entity_id", ids);
+
+    if (error) {
+      logger.error("module-zero-batch.getFlagsSummaryMap failed", error);
+      return new Map();
     }
-    map.set(row.entity_id, existing);
+
+    for (const row of (data || []) as Array<{
+      entity_id: string;
+      status: string | null;
+    }>) {
+      const existing = map.get(row.entity_id) || {
+        openCount: 0,
+        totalCount: 0,
+      };
+      existing.totalCount += 1;
+      if (!row.status || !CLOSED_FLAG_STATUSES.has(row.status)) {
+        existing.openCount += 1;
+      }
+      map.set(row.entity_id, existing);
+    }
   }
   return map;
 }
@@ -178,9 +246,8 @@ export async function getFlagsSummaryMap(
 /**
  * Latest revision per peopleId.
  *
- * Single query: `revisions` filtered by `entity_id IN (...)`, ordered by
- * `created_at DESC`. The first row seen per entity wins — guaranteed to be
- * the most recent given the order clause.
+ * Single query (per chunk): `revisions` filtered by `entity_id IN (...)`,
+ * ordered by `created_at DESC`. First row seen per entity wins.
  */
 export async function getLatestRevisionMap(
   peopleIds: string[]
@@ -188,39 +255,43 @@ export async function getLatestRevisionMap(
   if (peopleIds.length === 0) return new Map();
 
   const supabase = createServerClient();
-  const { data, error } = await supabase
-    .from("revisions")
-    .select(
-      "id, entity_id, field_path, new_value, changed_by, change_reason, created_at"
-    )
-    .order("created_at", { ascending: false })
-    .in("entity_id", peopleIds);
-
-  if (error) {
-    logger.error("module-zero-batch.getLatestRevisionMap failed", error);
-    return new Map();
-  }
+  const idChunks = chunk(peopleIds, CHUNK_SIZE);
 
   const map = new Map<string, Revision>();
-  for (const row of (data || []) as Array<{
-    id: string;
-    entity_id: string;
-    field_path: string | null;
-    new_value: unknown;
-    changed_by: string | null;
-    change_reason: string | null;
-    created_at: string;
-  }>) {
-    if (map.has(row.entity_id)) continue;
-    map.set(row.entity_id, {
-      id: row.id,
-      entityId: row.entity_id,
-      fieldPath: row.field_path,
-      newValue: row.new_value,
-      changedBy: row.changed_by,
-      changeReason: row.change_reason,
-      createdAt: row.created_at,
-    });
+  for (const ids of idChunks) {
+    const { data, error } = await supabase
+      .from("revisions")
+      .select(
+        "id, entity_id, field_path, new_value, changed_by, change_reason, created_at"
+      )
+      .order("created_at", { ascending: false })
+      .in("entity_id", ids);
+
+    if (error) {
+      logger.error("module-zero-batch.getLatestRevisionMap failed", error);
+      return new Map();
+    }
+
+    for (const row of (data || []) as Array<{
+      id: string;
+      entity_id: string;
+      field_path: string | null;
+      new_value: unknown;
+      changed_by: string | null;
+      change_reason: string | null;
+      created_at: string;
+    }>) {
+      if (map.has(row.entity_id)) continue;
+      map.set(row.entity_id, {
+        id: row.id,
+        entityId: row.entity_id,
+        fieldPath: row.field_path,
+        newValue: row.new_value,
+        changedBy: row.changed_by,
+        changeReason: row.change_reason,
+        createdAt: row.created_at,
+      });
+    }
   }
   return map;
 }

--- a/src/lib/supabase/queries/afrik/module-zero-batch.ts
+++ b/src/lib/supabase/queries/afrik/module-zero-batch.ts
@@ -1,0 +1,226 @@
+/**
+ * Module #0 N+1 batch helpers (ETNI-24).
+ *
+ * Public fiche routes need source-transparency data (sources, confidence,
+ * flag summary, latest revision) for many peopleIds at once. Naive code
+ * issues one query per id (N+1). These helpers each perform exactly ONE
+ * Supabase round-trip for N inputs and return `Map<peopleId, T>` for O(1)
+ * caller lookups.
+ *
+ * Schema assumption: the Module #0 tables (sources, assertions,
+ * confidence_scores, flags, revisions) follow the 008 layout reconciled by
+ * ETNI-22 / migration 014 — every entity row exposes an `entity_id` column
+ * referencing the AFRIK people id. If a future migration renames columns,
+ * this file is the single place to update.
+ *
+ * All helpers:
+ *  - short-circuit on empty input (no query),
+ *  - log failures through `@/lib/api/logger` (never `console.*`),
+ *  - return an empty Map on error so callers never break the page.
+ */
+
+import { createServerClient } from "../../server";
+import { logger } from "@/lib/api/logger";
+
+// ---------------------------------------------------------------------------
+// Types — kept local to avoid coupling fiche routes to DB-row shapes. When
+// ETNI-22 lands, these can be promoted to `@/types/afrik` if other modules
+// need them.
+// ---------------------------------------------------------------------------
+
+export interface Source {
+  id: string;
+  title: string;
+  url: string | null;
+  type: string | null;
+}
+
+export interface ConfidenceScore {
+  id: string;
+  score: number;
+  methodology: string | null;
+}
+
+export interface FlagSummary {
+  openCount: number;
+  totalCount: number;
+}
+
+export interface Revision {
+  id: string;
+  entityId: string;
+  fieldPath: string | null;
+  newValue: unknown;
+  changedBy: string | null;
+  changeReason: string | null;
+  createdAt: string;
+}
+
+// Flag statuses considered "closed" — anything else counts as open.
+const CLOSED_FLAG_STATUSES = new Set(["resolved", "dismissed"]);
+
+/**
+ * Sources cited by assertions tied to the given peopleIds.
+ *
+ * Single query: `assertions` filtered by `entity_id IN (...)`, with the
+ * referenced `sources` row embedded via the FK. Grouped client-side.
+ */
+export async function getSourcesMap(
+  peopleIds: string[]
+): Promise<Map<string, Source[]>> {
+  if (peopleIds.length === 0) return new Map();
+
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from("assertions")
+    .select("entity_id, sources(id, title, url, type)")
+    .in("entity_id", peopleIds);
+
+  if (error) {
+    logger.error("module-zero-batch.getSourcesMap failed", error);
+    return new Map();
+  }
+
+  const map = new Map<string, Source[]>();
+  for (const row of (data || []) as Array<{
+    entity_id: string;
+    sources: Source | Source[] | null;
+  }>) {
+    if (!row.sources) continue;
+    const sources = Array.isArray(row.sources) ? row.sources : [row.sources];
+    const existing = map.get(row.entity_id) || [];
+    for (const src of sources) {
+      if (src) existing.push(src);
+    }
+    map.set(row.entity_id, existing);
+  }
+  return map;
+}
+
+/**
+ * Latest confidence score per peopleId.
+ *
+ * Single query: `assertions` filtered by `entity_id IN (...)`, with the
+ * latest `confidence_scores` row embedded. If multiple confidence rows exist
+ * we keep the first non-null seen per peopleId; callers can fold further if
+ * needed (out of scope for this story).
+ */
+export async function getConfidenceMap(
+  peopleIds: string[]
+): Promise<Map<string, ConfidenceScore>> {
+  if (peopleIds.length === 0) return new Map();
+
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from("assertions")
+    .select("entity_id, confidence_scores(id, score, methodology)")
+    .in("entity_id", peopleIds);
+
+  if (error) {
+    logger.error("module-zero-batch.getConfidenceMap failed", error);
+    return new Map();
+  }
+
+  const map = new Map<string, ConfidenceScore>();
+  for (const row of (data || []) as Array<{
+    entity_id: string;
+    confidence_scores: ConfidenceScore | ConfidenceScore[] | null;
+  }>) {
+    if (map.has(row.entity_id)) continue;
+    if (!row.confidence_scores) continue;
+    const cs = Array.isArray(row.confidence_scores)
+      ? row.confidence_scores[0]
+      : row.confidence_scores;
+    if (cs) map.set(row.entity_id, cs);
+  }
+  return map;
+}
+
+/**
+ * Per-peopleId flag summary: total flag count and the subset still "open"
+ * (status not in {resolved, dismissed}).
+ *
+ * Single query: `flags` filtered by `entity_id IN (...)`. Aggregation is
+ * cheap in-memory because the result set is bounded by the active flags
+ * touching the requested peoples.
+ */
+export async function getFlagsSummaryMap(
+  peopleIds: string[]
+): Promise<Map<string, FlagSummary>> {
+  if (peopleIds.length === 0) return new Map();
+
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from("flags")
+    .select("entity_id, status")
+    .in("entity_id", peopleIds);
+
+  if (error) {
+    logger.error("module-zero-batch.getFlagsSummaryMap failed", error);
+    return new Map();
+  }
+
+  const map = new Map<string, FlagSummary>();
+  for (const row of (data || []) as Array<{
+    entity_id: string;
+    status: string | null;
+  }>) {
+    const existing = map.get(row.entity_id) || { openCount: 0, totalCount: 0 };
+    existing.totalCount += 1;
+    if (!row.status || !CLOSED_FLAG_STATUSES.has(row.status)) {
+      existing.openCount += 1;
+    }
+    map.set(row.entity_id, existing);
+  }
+  return map;
+}
+
+/**
+ * Latest revision per peopleId.
+ *
+ * Single query: `revisions` filtered by `entity_id IN (...)`, ordered by
+ * `created_at DESC`. The first row seen per entity wins — guaranteed to be
+ * the most recent given the order clause.
+ */
+export async function getLatestRevisionMap(
+  peopleIds: string[]
+): Promise<Map<string, Revision>> {
+  if (peopleIds.length === 0) return new Map();
+
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from("revisions")
+    .select(
+      "id, entity_id, field_path, new_value, changed_by, change_reason, created_at"
+    )
+    .order("created_at", { ascending: false })
+    .in("entity_id", peopleIds);
+
+  if (error) {
+    logger.error("module-zero-batch.getLatestRevisionMap failed", error);
+    return new Map();
+  }
+
+  const map = new Map<string, Revision>();
+  for (const row of (data || []) as Array<{
+    id: string;
+    entity_id: string;
+    field_path: string | null;
+    new_value: unknown;
+    changed_by: string | null;
+    change_reason: string | null;
+    created_at: string;
+  }>) {
+    if (map.has(row.entity_id)) continue;
+    map.set(row.entity_id, {
+      id: row.id,
+      entityId: row.entity_id,
+      fieldPath: row.field_path,
+      newValue: row.new_value,
+      changedBy: row.changed_by,
+      changeReason: row.change_reason,
+      createdAt: row.created_at,
+    });
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary

- ETNI-24: batch read helpers for Module #0 data (sources / confidence / flags-summary / latest-revision).
- New file `src/lib/supabase/queries/afrik/module-zero-batch.ts`.
- Each helper: exactly 1 SQL query per call regardless of input length.

## Refined ACs covered

- `getSourcesMap(peopleIds)` → `Map<peopleId, Source[]>` via single `.in('entity_id', ids)` query.
- `getConfidenceMap(peopleIds)` → `Map<peopleId, ConfidenceScore>`.
- `getFlagsSummaryMap(peopleIds)` → `Map<peopleId, { openCount, totalCount }>`.
- `getLatestRevisionMap(peopleIds)` → `Map<peopleId, Revision>`.
- Tests with 50 IDs assert exactly 1 query per helper.
- Error path uses `logger.error` (no `console.*`).

## Out of scope

- Wiring helpers into existing fiche routes → follow-up PR.

## Test plan

- [x] `npx vitest run src/lib/supabase/queries/afrik/__tests__/module-zero-batch.test.ts`
- [x] `npm run type-check`
