### PR TITLE
ETNI-28: DoctrineLinkCard component

### DIFF
--- a/src/components/source-transparency/DoctrineLinkCard.stories.tsx
+++ b/src/components/source-transparency/DoctrineLinkCard.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DoctrineLinkCard } from "./DoctrineLinkCard";
+
+const meta: Meta<typeof DoctrineLinkCard> = {
+  title: "Source Transparency/DoctrineLinkCard",
+  component: DoctrineLinkCard,
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+  argTypes: {
+    slug: {
+      control: "select",
+      options: [
+        "endonymes-vs-exonymes",
+        "classifications-contestees",
+        "heritage-colonial",
+        "topics-sensibles",
+      ],
+    },
+    version: {
+      control: { type: "number", min: 1 },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DoctrineLinkCard>;
+
+/**
+ * Endonymes vs. exonymes — live (no version pinned). The historical note is
+ * rendered to signal that this doctrine link follows the latest published
+ * version.
+ */
+export const EndonymesLive: Story = {
+  name: "Endonymes vs. exonymes — live",
+  args: { slug: "endonymes-vs-exonymes" },
+};
+
+/**
+ * Endonymes vs. exonymes — pinned to v1. The historical note disappears,
+ * the URL embeds the `@v1` suffix.
+ */
+export const EndonymesPinnedV1: Story = {
+  name: "Endonymes vs. exonymes — pinned v1",
+  args: { slug: "endonymes-vs-exonymes", version: 1 },
+};
+
+export const ClassificationsContesteesLive: Story = {
+  name: "Classifications contestées — live",
+  args: { slug: "classifications-contestees" },
+};
+
+export const ClassificationsContesteesPinnedV2: Story = {
+  name: "Classifications contestées — pinned v2",
+  args: { slug: "classifications-contestees", version: 2 },
+};
+
+export const HeritageColonialLive: Story = {
+  name: "Héritage colonial — live",
+  args: { slug: "heritage-colonial" },
+};
+
+export const HeritageColonialPinnedV1: Story = {
+  name: "Héritage colonial — pinned v1",
+  args: { slug: "heritage-colonial", version: 1 },
+};
+
+export const TopicsSensiblesLive: Story = {
+  name: "Topics sensibles — live",
+  args: { slug: "topics-sensibles" },
+};
+
+export const TopicsSensiblesPinnedV3: Story = {
+  name: "Topics sensibles — pinned v3",
+  args: { slug: "topics-sensibles", version: 3 },
+};

--- a/src/components/source-transparency/DoctrineLinkCard.tsx
+++ b/src/components/source-transparency/DoctrineLinkCard.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+
+export type DoctrineSlug =
+  | "endonymes-vs-exonymes"
+  | "classifications-contestees"
+  | "heritage-colonial"
+  | "topics-sensibles";
+
+export type DoctrineLinkCardProps = {
+  slug: DoctrineSlug;
+  /** When undefined, the link points to the live doctrine and a historical note is rendered. */
+  version?: number;
+};
+
+const DOCTRINE_COPY: Record<DoctrineSlug, string> = {
+  "endonymes-vs-exonymes":
+    "Cette fiche utilise endonymes (auto-désignations) et exonymes (désignations extérieures). Lisez la doctrine pour comprendre nos choix.",
+  "classifications-contestees":
+    "Cette classification fait l'objet de débats académiques et de positionnements éditoriaux. Voir la doctrine.",
+  "heritage-colonial":
+    "Ce terme provient de l'héritage colonial. Nous le conservons en l'expliquant. Voir la doctrine.",
+  "topics-sensibles":
+    "Ce sujet est sensible. Notre doctrine éditoriale encadre la rédaction. Voir la doctrine.",
+};
+
+const HISTORICAL_NOTE =
+  "version en vigueur au moment de la publication — historique disponible prochainement";
+
+export function DoctrineLinkCard({ slug, version }: DoctrineLinkCardProps) {
+  const copy = DOCTRINE_COPY[slug];
+  const href =
+    version !== undefined
+      ? `/fr/doctrine/${slug}@v${version}`
+      : `/fr/doctrine/${slug}`;
+
+  return (
+    <aside
+      className="rounded-[var(--country-radius-xl,16px)] xl:rounded-[20px] px-[18px] py-[16px] md:px-[24px] md:py-[20px] xl:px-[28px] xl:py-[22px] text-[13px] md:text-[14px] leading-[1.6]"
+      style={{
+        backgroundColor: "var(--afh-bg-warm, var(--country-bg))",
+        color: "var(--country-text, #1a1a1a)",
+      }}
+    >
+      <p className="mb-[8px]">{copy}</p>
+      <Link
+        href={href}
+        className="inline-block font-semibold underline underline-offset-2 hover:no-underline"
+        style={{ color: "var(--country-earth, currentColor)" }}
+      >
+        Lire la doctrine
+      </Link>
+      {version === undefined && (
+        <p
+          className="mt-[6px] text-[11px] md:text-[12px] italic"
+          style={{ color: "var(--country-text-soft, #6b6b6b)" }}
+        >
+          {HISTORICAL_NOTE}
+        </p>
+      )}
+    </aside>
+  );
+}

--- a/src/components/source-transparency/__tests__/DoctrineLinkCard.test.tsx
+++ b/src/components/source-transparency/__tests__/DoctrineLinkCard.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DoctrineLinkCard } from "../DoctrineLinkCard";
+
+describe("DoctrineLinkCard", () => {
+  describe("French explanatory copy per slug", () => {
+    it("renders endonymes-vs-exonymes copy", () => {
+      render(<DoctrineLinkCard slug="endonymes-vs-exonymes" />);
+      expect(
+        screen.getByText(/endonymes \(auto-désignations\) et exonymes/i)
+      ).toBeInTheDocument();
+    });
+
+    it("renders classifications-contestees copy", () => {
+      render(<DoctrineLinkCard slug="classifications-contestees" />);
+      expect(
+        screen.getByText(/classification fait l'objet de débats académiques/i)
+      ).toBeInTheDocument();
+    });
+
+    it("renders heritage-colonial copy", () => {
+      render(<DoctrineLinkCard slug="heritage-colonial" />);
+      expect(
+        screen.getByText(/terme provient de l'héritage colonial/i)
+      ).toBeInTheDocument();
+    });
+
+    it("renders topics-sensibles copy", () => {
+      render(<DoctrineLinkCard slug="topics-sensibles" />);
+      expect(
+        screen.getByText(/sujet est sensible\. Notre doctrine éditoriale/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Live (no version) link target", () => {
+    it("renders /fr/doctrine/<slug> link when version is undefined", () => {
+      render(<DoctrineLinkCard slug="endonymes-vs-exonymes" />);
+      const link = screen.getByRole("link");
+      expect(link).toHaveAttribute(
+        "href",
+        "/fr/doctrine/endonymes-vs-exonymes"
+      );
+    });
+
+    it("renders the historical note when version is undefined", () => {
+      render(<DoctrineLinkCard slug="heritage-colonial" />);
+      expect(
+        screen.getByText(
+          /version en vigueur au moment de la publication — historique disponible prochainement/i
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Pinned (with version) link target", () => {
+    it("renders /fr/doctrine/<slug>@v1 link when version=1", () => {
+      render(
+        <DoctrineLinkCard slug="classifications-contestees" version={1} />
+      );
+      const link = screen.getByRole("link");
+      expect(link).toHaveAttribute(
+        "href",
+        "/fr/doctrine/classifications-contestees@v1"
+      );
+    });
+
+    it("does NOT render the historical note when version is provided", () => {
+      render(<DoctrineLinkCard slug="topics-sensibles" version={2} />);
+      expect(
+        screen.queryByText(/version en vigueur au moment de la publication/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- ETNI-28: warm-background card linking fiche sections to the editorial doctrine.
- New `src/components/source-transparency/DoctrineLinkCard.tsx` + tests + Storybook story.
- 4 slug presets with French explanatory copy.

## Refined ACs covered

- `--afh-bg-warm` background with `--country-bg` fallback.
- Static French copy per slug.
- Version-aware link target: `/fr/doctrine/{slug}@v{n}` when pinned; otherwise live URL with historical note.
- Storybook story with mock data for each slug + version variants.

## Out of scope

- Doctrine MDX page itself is ETNI-30.
- Fiche integration → follow-up.

## Test plan

- [x] `npx vitest run src/components/source-transparency/__tests__/DoctrineLinkCard.test.tsx`
- [x] `npm run type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
