### PR TITLE
ETNI-26: ClassificationBadge — no red, mono-safe, breakpoint stories

### DIFF
--- a/src/components/ui/__tests__/classification-badge.test.tsx
+++ b/src/components/ui/__tests__/classification-badge.test.tsx
@@ -1,13 +1,15 @@
 /**
- * Tests for ClassificationBadge (ETNI-178).
+ * Tests for ClassificationBadge (ETNI-178 + ETNI-26 enhancement).
  *
  * The component surfaces the editorial `classification_status` enum on people
  * and language-family fiches. It MUST:
  *   - render the FR label for each enum value,
- *   - return null (no DOM output) when the status is nullish,
+ *   - return null (no DOM output) when the status is nullish OR when the
+ *     status is `consensual` (the default state — no badge needed),
  *   - wrap the badge in a Next.js Link to /fr/doctrine#<status>,
- *   - expose the tooltip text (via title attribute, since we render outside a
- *     TooltipProvider in tests).
+ *   - expose the tooltip text (via title attribute),
+ *   - pair each label with an icon (monochrome-safe — color is never the sole signal),
+ *   - never use red color tokens (warm hue only: earth / terracotta / gold).
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -33,16 +35,21 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+// Statuses that produce a visible badge (consensual returns null — see ETNI-26).
+const VISIBLE_STATUSES = [
+  "contested",
+  "colonial-legacy",
+  "reconstructive",
+] as const;
+
 describe("ClassificationBadge", () => {
-  it.each([
-    ["consensual" as const, classificationLabels.consensual.label],
-    ["contested" as const, classificationLabels.contested.label],
-    ["colonial-legacy" as const, classificationLabels["colonial-legacy"].label],
-    ["reconstructive" as const, classificationLabels.reconstructive.label],
-  ])("renders the FR label for status=%s", (status, expectedLabel) => {
-    render(<ClassificationBadge status={status} />);
-    expect(screen.getByText(expectedLabel)).toBeInTheDocument();
-  });
+  it.each(VISIBLE_STATUSES.map((s) => [s, classificationLabels[s].label]))(
+    "renders the FR label for status=%s",
+    (status, expectedLabel) => {
+      render(<ClassificationBadge status={status} />);
+      expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+    }
+  );
 
   it("returns null when status is null", () => {
     const { container } = render(<ClassificationBadge status={null} />);
@@ -54,16 +61,19 @@ describe("ClassificationBadge", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it.each([
-    ["consensual" as const],
-    ["contested" as const],
-    ["colonial-legacy" as const],
-    ["reconstructive" as const],
-  ])("links to /fr/doctrine#%s", (status) => {
-    render(<ClassificationBadge status={status} />);
-    const link = screen.getByRole("link");
-    expect(link).toHaveAttribute("href", `/fr/doctrine#${status}`);
+  it("returns null when status is consensual (default — no badge needed)", () => {
+    const { container } = render(<ClassificationBadge status="consensual" />);
+    expect(container).toBeEmptyDOMElement();
   });
+
+  it.each(VISIBLE_STATUSES.map((s) => [s]))(
+    "links to /fr/doctrine#%s",
+    (status) => {
+      render(<ClassificationBadge status={status} />);
+      const link = screen.getByRole("link");
+      expect(link).toHaveAttribute("href", `/fr/doctrine#${status}`);
+    }
+  );
 
   it("exposes the tooltip text via title attribute", () => {
     render(<ClassificationBadge status="contested" />);
@@ -81,5 +91,56 @@ describe("ClassificationBadge", () => {
       "title",
       classificationLabels["colonial-legacy"].tooltip
     );
+  });
+
+  it.each(VISIBLE_STATUSES.map((s) => [s]))(
+    "pairs the label with an icon (monochrome-safe) for status=%s",
+    (status) => {
+      render(<ClassificationBadge status={status} />);
+      // The icon carries a deterministic testid the consumer can rely on.
+      expect(screen.getByTestId("classification-icon")).toBeInTheDocument();
+    }
+  );
+
+  it.each(VISIBLE_STATUSES.map((s) => [s]))(
+    "never applies a red color token for status=%s",
+    (status) => {
+      render(<ClassificationBadge status={status} />);
+      const link = screen.getByRole("link");
+      const inner = link.querySelector("[data-classification-status]");
+      // Inline style and class strings must not reference red tokens.
+      const inline = (inner as HTMLElement)?.getAttribute("style") ?? "";
+      const cls = (inner as HTMLElement)?.getAttribute("class") ?? "";
+      const haystack = `${inline} ${cls}`.toLowerCase();
+      expect(haystack).not.toMatch(/colonial[^-]/); // avoid --country-colonial (red)
+      expect(haystack).not.toMatch(/\bred\b/);
+      expect(haystack).not.toMatch(/#9b3030/);
+      expect(haystack).not.toMatch(/#a03f1a/); // the old hard-coded red-ish brown
+      // Foreground for the contested status used to be a brown-gold (#7A5807);
+      // we keep it warm but check that no "destructive" or "danger" hint slipped in.
+      expect(haystack).not.toMatch(/destructive|danger/);
+    }
+  );
+
+  it("accepts an optional doctrineSlug prop without breaking the link", () => {
+    // The prop is informational — it does NOT change the link target (the
+    // badge always points to the canonical doctrine anchor for its status).
+    // The doctrineSlug is exposed via a data attribute so callers / tests can
+    // verify pairing with an adjacent DoctrineLinkCard.
+    render(
+      <ClassificationBadge
+        status="contested"
+        doctrineSlug="classification-status"
+      />
+    );
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/fr/doctrine#contested");
+    expect(link).toHaveAttribute("data-doctrine-slug", "classification-status");
+  });
+
+  it("is backwards-compatible with the original single-prop call signature", () => {
+    // Existing call sites use <ClassificationBadge status={x} /> only.
+    render(<ClassificationBadge status="contested" />);
+    expect(screen.getByRole("link")).toBeInTheDocument();
   });
 });

--- a/src/components/ui/classification-badge.stories.tsx
+++ b/src/components/ui/classification-badge.stories.tsx
@@ -17,13 +17,25 @@ const meta: Meta<typeof ClassificationBadge> = {
         null,
       ],
     },
+    doctrineSlug: {
+      control: "text",
+      description:
+        "Slug of an adjacent DoctrineLinkCard. The badge exposes it via " +
+        "data-doctrine-slug; rendering the card is the caller's job.",
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof ClassificationBadge>;
 
+/**
+ * `consensual` is the default editorial state — the component intentionally
+ * returns `null` so we don't pollute fiches with low-signal badges. This
+ * story documents that contract.
+ */
 export const Consensual: Story = {
+  name: "Consensual (renders nothing)",
   args: { status: "consensual" },
 };
 
@@ -41,10 +53,111 @@ export const Reconstructive: Story = {
 };
 
 /**
- * When `status` is null the component must return nothing — no placeholder,
+ * When `status` is null the component returns nothing — no placeholder,
  * no layout shift. This story verifies that contract.
  */
 export const Null: Story = {
   name: "Null (renders nothing)",
   args: { status: null },
+};
+
+/**
+ * Shows the badge paired with a `doctrineSlug`. The slug surfaces as
+ * `data-doctrine-slug` on the link so an adjacent `DoctrineLinkCard` can
+ * find it; the badge itself does not render the card.
+ */
+export const WithDoctrineSlug: Story = {
+  name: "With doctrineSlug (caller renders the card)",
+  args: { status: "contested", doctrineSlug: "classification-status" },
+};
+
+// ---------------------------------------------------------------------------
+// Breakpoint variants — mobile-first per project conventions.
+//
+// We render the badge inside a fixed-width frame so the story preview shows
+// how it sits in different viewport widths. The badge itself is intrinsic;
+// the frame mimics the page container at each breakpoint.
+// ---------------------------------------------------------------------------
+
+const Frame = ({
+  width,
+  label,
+  children,
+}: {
+  width: number;
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <div
+    style={{
+      width,
+      maxWidth: "100%",
+      border: "1px dashed rgba(0,0,0,0.15)",
+      borderRadius: 8,
+      padding: 16,
+      display: "flex",
+      flexDirection: "column",
+      gap: 12,
+      background: "white",
+    }}
+  >
+    <div
+      style={{
+        fontFamily: "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto",
+        fontSize: 12,
+        color: "#666",
+      }}
+    >
+      {label} — {width}px
+    </div>
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>{children}</div>
+  </div>
+);
+
+const AllStatuses = () => (
+  <>
+    <ClassificationBadge status="contested" />
+    <ClassificationBadge status="colonial-legacy" />
+    <ClassificationBadge status="reconstructive" />
+  </>
+);
+
+export const Mobile430: Story = {
+  name: "Breakpoint — Mobile (430px)",
+  parameters: { layout: "padded" },
+  render: () => (
+    <Frame width={430} label="Mobile">
+      <AllStatuses />
+    </Frame>
+  ),
+};
+
+export const Tablet720: Story = {
+  name: "Breakpoint — Tablet (720px)",
+  parameters: { layout: "padded" },
+  render: () => (
+    <Frame width={720} label="Tablet">
+      <AllStatuses />
+    </Frame>
+  ),
+};
+
+export const Desktop800: Story = {
+  name: "Breakpoint — Desktop (800px)",
+  parameters: { layout: "padded" },
+  render: () => (
+    <Frame width={800} label="Desktop (country max-width)">
+      <AllStatuses />
+    </Frame>
+  ),
+};
+
+export const DesktopWide1024: Story = {
+  name: "Breakpoint — Desktop wide (1024px)",
+  parameters: { layout: "padded" },
+  render: () => (
+    <Frame width={1024} label="Desktop wide">
+      <AllStatuses />
+    </Frame>
+  ),
 };

--- a/src/components/ui/classification-badge.tsx
+++ b/src/components/ui/classification-badge.tsx
@@ -1,17 +1,33 @@
 /**
  * ClassificationBadge — surfaces the editorial `classification_status` enum
- * on people and language-family fiches (Story ETNI-178 / 0.21).
+ * on people and language-family fiches.
  *
- * Renders `null` when the status is nullish — no placeholder, no layout shift.
- * Clicking the badge sends the user to `/fr/doctrine#<status>` so they can
- * read the editorial doctrine that defines each status.
+ * Originally introduced in ETNI-178 (story 0.21). Refactored for ETNI-26
+ * ("Source Transparency Fabric" / [1.6]) to enforce the refined ACs:
  *
- * Color tokens come from `src/styles/country-tokens.css`. Foreground tokens
- * are designed for WCAG AA contrast against the corresponding `*-bg` token.
+ * - **No red, ever.** The previous `colonial-legacy` palette mapped to
+ *   `--country-colonial` (#9B3030, a red). It now uses warm earth tones via
+ *   `var(--afh-earth, var(--country-terracotta))` so when the AFH design
+ *   tokens land in ETNI-21 the badge inherits them automatically.
+ * - **French label + icon.** Color is never the sole signal — every variant
+ *   pairs the FR label with a lucide-react icon (monochrome-safe). The icon
+ *   carries `data-testid="classification-icon"` for downstream tests.
+ * - **`consensual` renders null.** Consensual is the default editorial state;
+ *   rendering it would be visual noise. The caller does not need a wrapper
+ *   guard — this component owns the contract.
+ * - **`doctrineSlug?` prop.** Lets callers pair the badge with a
+ *   `DoctrineLinkCard` for the same doctrine entry. The badge itself does
+ *   NOT render the card — adjacency is the caller's responsibility, keeping
+ *   the dependency one-way. The slug is exposed via `data-doctrine-slug`
+ *   so consumers and tests can verify pairing.
+ *
+ * The badge link always points to `/fr/doctrine#<status>`. The optional
+ * `doctrineSlug` is a marker for adjacent UI, not a router target.
  */
 
 import * as React from "react";
 import Link from "next/link";
+import { AlertTriangle, Landmark, Wrench, type LucideIcon } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -21,52 +37,76 @@ import type { ClassificationStatus } from "@/types/afrik";
 interface ClassificationBadgeProps {
   status: ClassificationStatus | null | undefined;
   className?: string;
+  /**
+   * Slug of an adjacent doctrine entry, exposed via `data-doctrine-slug` for
+   * callers that render a `DoctrineLinkCard` next to the badge. The badge
+   * does not render the card itself — adjacency is the caller's job.
+   */
+  doctrineSlug?: string;
 }
 
 /**
- * Maps each enum value to its country-token color pair (foreground / background).
- * Keeping inline styles here lets the badge use CSS custom properties without
- * pulling in a tailwind safelist for every new status.
+ * Maps each visible enum value to its display config.
+ *
+ * `fg` / `bg` use CSS custom properties with a fallback chain so the badge
+ * inherits the upcoming AFH tokens (ETNI-21) automatically while staying
+ * functional today against the existing `--country-*` palette.
+ *
+ * Crucially: NO red. `colonial-legacy` now uses the same warm earth tone as
+ * `reconstructive`, distinguished by the icon and the label.
  */
-const STATUS_COLORS: Record<ClassificationStatus, { fg: string; bg: string }> =
-  {
-    consensual: {
-      fg: "var(--country-green)",
-      bg: "var(--country-green-bg)",
-    },
-    contested: {
-      // WCAG AA: darker than --country-gold to reach 4.5:1 on --country-gold-bg
-      fg: "#7A5807",
-      bg: "var(--country-gold-bg)",
-    },
-    "colonial-legacy": {
-      fg: "var(--country-colonial)",
-      bg: "var(--country-colonial-bg)",
-    },
-    reconstructive: {
-      // WCAG AA: darker than --country-terracotta to reach 4.5:1 on --country-terracotta-bg
-      fg: "#A03F1A",
-      bg: "var(--country-terracotta-bg)",
-    },
-  };
+type StatusConfig = {
+  fg: string;
+  bg: string;
+  Icon: LucideIcon;
+};
+
+const STATUS_CONFIG: Record<
+  Exclude<ClassificationStatus, "consensual">,
+  StatusConfig
+> = {
+  contested: {
+    // Warm gold; darker than --country-gold to reach WCAG AA on --country-gold-bg.
+    fg: "var(--afh-earth, #7A5807)",
+    bg: "var(--afh-earth-bg, var(--country-gold-bg))",
+    Icon: AlertTriangle,
+  },
+  "colonial-legacy": {
+    // Warm earth — replaces the previous red #9B3030. Same hue family as
+    // terracotta but slightly darker for contrast against the bg token.
+    fg: "var(--afh-earth, #8A4A1F)",
+    bg: "var(--afh-earth-bg, var(--country-terracotta-bg))",
+    Icon: Landmark,
+  },
+  reconstructive: {
+    // Warm terracotta — darker than --country-terracotta for WCAG AA on bg.
+    fg: "var(--afh-terracotta, #A03F1A)",
+    bg: "var(--afh-terracotta-bg, var(--country-terracotta-bg))",
+    Icon: Wrench,
+  },
+};
 
 export function ClassificationBadge({
   status,
   className,
+  doctrineSlug,
 }: ClassificationBadgeProps) {
-  if (!status) {
+  // `null` / `undefined` and `consensual` (the default editorial state) both
+  // render nothing — no placeholder, no layout shift.
+  if (!status || status === "consensual") {
     return null;
   }
 
   const labels = classificationLabels[status];
-  const colors = STATUS_COLORS[status];
+  const config = STATUS_CONFIG[status];
+  const Icon = config.Icon;
 
   return (
     <Link
       href={`/fr/doctrine#${status}`}
       title={labels.tooltip}
       aria-label={`${labels.label} — ${labels.tooltip}`}
-      data-classification-status={status}
+      data-doctrine-slug={doctrineSlug}
       className={cn(
         "inline-flex focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-full",
         className
@@ -74,13 +114,19 @@ export function ClassificationBadge({
     >
       <Badge
         variant="outline"
-        className="border-transparent font-semibold"
+        data-classification-status={status}
+        className="gap-1.5 border-transparent font-semibold"
         style={{
-          backgroundColor: colors.bg,
-          color: colors.fg,
+          backgroundColor: config.bg,
+          color: config.fg,
         }}
       >
-        {labels.label}
+        <Icon
+          aria-hidden="true"
+          data-testid="classification-icon"
+          className="h-3.5 w-3.5 shrink-0"
+        />
+        <span>{labels.label}</span>
       </Badge>
     </Link>
   );


### PR DESCRIPTION
## Summary

- ETNI-26: refactor existing `ClassificationBadge` to meet refined ACs.
- No red ever (warm hue: `--afh-earth` / `--afh-terracotta` with `--country-*` fallback).
- French labels paired with icons (no emoji); monochrome-safe.
- New `doctrineSlug?: string` prop for caller-driven `DoctrineLinkCard` adjacency.
- Storybook story extended with 430 / 720 / 800 / 1024 px breakpoints.

## Refined ACs covered

- French labels + icon (no emoji).
- Never red. Warm hue tokens.
- Color is never the sole signal.
- `consensual` variant renders neutral (or returns null — see implementation).
- Breakpoint variants in Storybook.
- Backwards-compatible with existing call sites.

## Out of scope

- Doctrine card rendering happens at the call site; the badge exposes a prop.
- Fiche integration → follow-up.

## Test plan

- [x] `npx vitest run src/components/ui/__tests__/classification-badge.test.tsx`
- [x] `npm run type-check`
- [ ] Storybook visual check at 430 / 720 / 800 / 1024 px
