### PR TITLE
ETNI-25: ConfidenceChip component

### DIFF
--- a/src/components/source-transparency/ConfidenceChip.stories.tsx
+++ b/src/components/source-transparency/ConfidenceChip.stories.tsx
@@ -1,0 +1,179 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ConfidenceChip } from "./ConfidenceChip";
+
+const meta: Meta<typeof ConfidenceChip> = {
+  title: "Source Transparency/ConfidenceChip",
+  component: ConfidenceChip,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Tappable typographic pill placed at the end of any assertion on an AFRIK fiche. " +
+          "Renders `X % · N sources · vérifié YYYY-MM-DD`. No emoji, no icon, no color alarm. " +
+          "Tap target ≥ 44×44 px via wrapper padding. One-shot pulse on first session render.",
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["inline", "hero", "contested"],
+    },
+    confidenceScore: { control: { type: "number", min: 0, max: 100 } },
+    sourceCount: { control: { type: "number", min: 0 } },
+    lastHumanAuditAt: { control: "text" },
+    onOpen: { action: "open" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfidenceChip>;
+
+export const Inline: Story = {
+  args: {
+    confidenceScore: 87,
+    sourceCount: 4,
+    lastHumanAuditAt: "2025-09-21",
+    variant: "inline",
+  },
+  render: (args) => (
+    <p className="max-w-xl text-base leading-relaxed">
+      Les Yoruba forment l&apos;un des plus grands groupes ethniques
+      d&apos;Afrique occidentale, présents principalement au Nigeria, au Bénin
+      et au Togo. <ConfidenceChip {...args} />
+    </p>
+  ),
+};
+
+export const Hero: Story = {
+  args: {
+    confidenceScore: 92,
+    sourceCount: 6,
+    lastHumanAuditAt: "2025-10-04",
+    variant: "hero",
+  },
+  render: (args) => (
+    <div className="max-w-xl">
+      <h1 className="text-3xl font-bold mb-3">Peuple Yoruba</h1>
+      <p className="text-lg leading-relaxed">
+        Riche héritage culturel et religieux d&apos;Afrique occidentale.{" "}
+        <ConfidenceChip {...args} />
+      </p>
+    </div>
+  ),
+};
+
+export const Contested: Story = {
+  args: {
+    confidenceScore: 42,
+    sourceCount: 2,
+    lastHumanAuditAt: "2025-04-10",
+    variant: "contested",
+  },
+  render: (args) => (
+    <p className="max-w-xl text-base leading-relaxed">
+      Certains historiens estiment que la migration initiale aurait eu lieu vers
+      le VIII<sup>e</sup> siècle, mais cette datation reste discutée.{" "}
+      <ConfidenceChip {...args} />
+    </p>
+  ),
+};
+
+export const MissingData: Story = {
+  name: "Fallback — missing data",
+  args: {
+    confidenceScore: null,
+    sourceCount: null,
+    lastHumanAuditAt: null,
+    variant: "inline",
+  },
+  render: (args) => (
+    <p className="max-w-xl text-base leading-relaxed">
+      Cette assertion n&apos;a pas encore été auditée — la fiche affiche un lien
+      générique. <ConfidenceChip {...args} />
+    </p>
+  ),
+};
+
+export const NoOnOpen: Story = {
+  name: "Without onOpen callback",
+  args: {
+    confidenceScore: 78,
+    sourceCount: 3,
+    lastHumanAuditAt: "2025-07-15",
+    variant: "inline",
+    onOpen: undefined,
+  },
+  render: (args) => (
+    <p className="max-w-xl text-base leading-relaxed">
+      Quand aucun gestionnaire n&apos;est fourni, le clic est silencieux mais le
+      chip reste focusable et accessible. <ConfidenceChip {...args} />
+    </p>
+  ),
+};
+
+export const AllVariants: Story = {
+  name: "All variants side-by-side",
+  parameters: { layout: "padded" },
+  render: () => (
+    <div className="space-y-6 max-w-xl">
+      <div>
+        <p className="text-xs uppercase tracking-wide text-muted-foreground mb-1">
+          Inline (default)
+        </p>
+        <p className="text-base">
+          Texte d&apos;assertion factuelle.{" "}
+          <ConfidenceChip
+            confidenceScore={87}
+            sourceCount={4}
+            lastHumanAuditAt="2025-09-21"
+            variant="inline"
+          />
+        </p>
+      </div>
+      <div>
+        <p className="text-xs uppercase tracking-wide text-muted-foreground mb-1">
+          Hero
+        </p>
+        <p className="text-lg">
+          Assertion mise en avant.{" "}
+          <ConfidenceChip
+            confidenceScore={92}
+            sourceCount={6}
+            lastHumanAuditAt="2025-10-04"
+            variant="hero"
+          />
+        </p>
+      </div>
+      <div>
+        <p className="text-xs uppercase tracking-wide text-muted-foreground mb-1">
+          Contested
+        </p>
+        <p className="text-base">
+          Assertion débattue par les sources.{" "}
+          <ConfidenceChip
+            confidenceScore={42}
+            sourceCount={2}
+            lastHumanAuditAt="2025-04-10"
+            variant="contested"
+          />
+        </p>
+      </div>
+      <div>
+        <p className="text-xs uppercase tracking-wide text-muted-foreground mb-1">
+          Missing data — fallback link
+        </p>
+        <p className="text-base">
+          Assertion non auditée.{" "}
+          <ConfidenceChip
+            confidenceScore={null}
+            sourceCount={null}
+            lastHumanAuditAt={null}
+          />
+        </p>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/source-transparency/ConfidenceChip.tsx
+++ b/src/components/source-transparency/ConfidenceChip.tsx
@@ -10,8 +10,8 @@ import { cn } from "@/lib/utils";
  *   `X % · N sources · vérifié YYYY-MM-DD`
  *
  * - No emoji, no icon, no color alarm.
- * - 44×44 px tap target via wrapper padding (even when visual pill is smaller).
- * - One-shot subtle pulse on first render in a session (honors prefers-reduced-motion).
+ * - 44×44 px tap target enforced directly on the button.
+ * - One-shot subtle pulse on first render in a session, per-chip (honors prefers-reduced-motion).
  * - Falls back to a "voir les sources" text link when any data field is missing.
  *
  * Tokens: uses `--afh-*` (ETNI-21) with `--country-*` fallback so this PR is
@@ -19,34 +19,85 @@ import { cn } from "@/lib/utils";
  * callers wire the sheet via the `onOpen` callback.
  */
 
-const SESSION_PULSE_KEY = "afh-chip-pulsed";
+const SESSION_PULSE_KEY = "afh-chip-pulsed-ids";
+const KEYFRAMES_STYLE_ID = "afh-chip-keyframes";
 
 export type ConfidenceChipVariant = "inline" | "hero" | "contested";
 
 export type ConfidenceChipProps = {
   confidenceScore: number | null;
   sourceCount: number | null;
-  lastHumanAuditAt: string | null; // ISO date (YYYY-MM-DD or full ISO)
+  lastHumanAuditAt: string | null;
   variant?: ConfidenceChipVariant;
   onOpen?: () => void;
   ariaSuffix?: string;
+  id?: string;
 };
 
 function toIsoShortDate(value: string): string {
-  // Keep the leading YYYY-MM-DD slice from any ISO string.
   return value.slice(0, 10);
 }
 
 function toLongFrenchDate(value: string): string {
-  const date = new Date(value);
+  const isoDate = value.slice(0, 10);
+  const parts = isoDate.split("-").map(Number);
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) {
+    return value;
+  }
+  const [y, m, d] = parts;
+  const date = new Date(y, m - 1, d);
   if (Number.isNaN(date.getTime())) {
     return value;
   }
-  return date.toLocaleDateString("fr-FR", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
+  return new Intl.DateTimeFormat("fr-FR", { dateStyle: "long" }).format(date);
+}
+
+function readPulsedIds(): Set<string> {
+  try {
+    const raw = window.sessionStorage.getItem(SESSION_PULSE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed))
+      return new Set(parsed.filter((v) => typeof v === "string"));
+    return new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writePulsedIds(ids: Set<string>): void {
+  try {
+    window.sessionStorage.setItem(
+      SESSION_PULSE_KEY,
+      JSON.stringify(Array.from(ids))
+    );
+  } catch {
+    // sessionStorage may throw in private mode — silently degrade.
+  }
+}
+
+function ensureKeyframesInjected(): void {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(KEYFRAMES_STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = KEYFRAMES_STYLE_ID;
+  style.textContent = `
+@keyframes afhChipPulse {
+  0% { box-shadow: 0 0 0 0 var(--afh-conf-pulse, rgba(184, 134, 11, 0.35)); }
+  70% { box-shadow: 0 0 0 6px var(--afh-conf-pulse-fade, rgba(184, 134, 11, 0)); }
+  100% { box-shadow: 0 0 0 0 var(--afh-conf-pulse-fade, rgba(184, 134, 11, 0)); }
+}
+.afh-chip-pulse {
+  animation: afhChipPulse var(--afh-motion-pulse, 1200ms) ease-out 1;
+}
+@media (prefers-reduced-motion: reduce) {
+  .afh-chip-pulse {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
+`;
+  document.head.appendChild(style);
 }
 
 export function ConfidenceChip({
@@ -56,6 +107,7 @@ export function ConfidenceChip({
   variant = "inline",
   onOpen,
   ariaSuffix,
+  id,
 }: ConfidenceChipProps) {
   const hasAllData =
     confidenceScore !== null &&
@@ -71,18 +123,16 @@ export function ConfidenceChip({
   React.useEffect(() => {
     if (!hasAllData) return;
     if (typeof window === "undefined") return;
-    try {
-      const alreadyPulsed = window.sessionStorage.getItem(SESSION_PULSE_KEY);
-      if (!alreadyPulsed) {
-        setShouldPulse(true);
-        window.sessionStorage.setItem(SESSION_PULSE_KEY, "1");
-      }
-    } catch {
-      // sessionStorage may throw in private mode — silently degrade (no pulse).
+    ensureKeyframesInjected();
+    const pulseKey = id ?? "__default__";
+    const seen = readPulsedIds();
+    if (!seen.has(pulseKey)) {
+      setShouldPulse(true);
+      seen.add(pulseKey);
+      writePulsedIds(seen);
     }
-  }, [hasAllData]);
+  }, [hasAllData, id]);
 
-  // ---- Fallback: missing data → "voir les sources" text link.
   if (!hasAllData) {
     return (
       <span className="inline-flex items-center p-1">
@@ -111,15 +161,6 @@ export function ConfidenceChip({
     ? `${baseAriaLabel} ${ariaSuffix}`
     : baseAriaLabel;
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      if (onOpen) onOpen();
-    }
-  };
-
-  // Variant-specific typographic distinction — NO red, NO alarm.
-  // We only tune size, font-weight and emphasis. Colors stay neutral/earthy.
   const variantClasses: Record<ConfidenceChipVariant, string> = {
     inline:
       "text-xs font-medium tracking-tight text-[color:var(--afh-text-soft,var(--country-text-soft,#7A6B5D))]",
@@ -132,17 +173,15 @@ export function ConfidenceChip({
     "bg-[color:var(--afh-conf-bg,var(--country-card,#FFFFFF))] border border-[color:var(--afh-border,var(--country-border,#E8DFD3))]";
 
   return (
-    <span className="afh-chip-wrapper inline-flex items-center align-baseline p-2 -m-2">
+    <span className="afh-chip-wrapper inline-flex items-center align-baseline">
       <button
         type="button"
         aria-label={ariaLabel}
         onClick={() => {
           if (onOpen) onOpen();
         }}
-        onKeyDown={handleKeyDown}
         className={cn(
-          // Tap target: wrapper padding plus min sizing on the button itself.
-          "inline-flex items-center justify-center min-h-[28px] min-w-[28px] px-2 py-1 rounded-full",
+          "inline-flex items-center justify-center p-3 min-h-[44px] min-w-[44px] rounded-full",
           "whitespace-nowrap select-none",
           "transition-colors",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
@@ -155,29 +194,6 @@ export function ConfidenceChip({
       >
         <span className="afh-chip-text">{pillText}</span>
       </button>
-
-      <style
-        // Inline keyframes for the one-shot pulse. Kept minimal and scoped via the
-        // `.afh-chip-pulse` class. `prefers-reduced-motion` neutralises the duration.
-        dangerouslySetInnerHTML={{
-          __html: `
-@keyframes afhChipPulse {
-  0% { box-shadow: 0 0 0 0 var(--afh-conf-pulse, rgba(184, 134, 11, 0.35)); }
-  70% { box-shadow: 0 0 0 6px var(--afh-conf-pulse-fade, rgba(184, 134, 11, 0)); }
-  100% { box-shadow: 0 0 0 0 var(--afh-conf-pulse-fade, rgba(184, 134, 11, 0)); }
-}
-.afh-chip-pulse {
-  animation: afhChipPulse var(--afh-motion-pulse, 1200ms) ease-out 1;
-}
-@media (prefers-reduced-motion: reduce) {
-  .afh-chip-pulse {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-  }
-}
-`,
-        }}
-      />
     </span>
   );
 }

--- a/src/components/source-transparency/ConfidenceChip.tsx
+++ b/src/components/source-transparency/ConfidenceChip.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * ConfidenceChip — L3 component (ETNI-25)
+ *
+ * Renders a tappable typographic pill at the end of an assertion:
+ *   `X % · N sources · vérifié YYYY-MM-DD`
+ *
+ * - No emoji, no icon, no color alarm.
+ * - 44×44 px tap target via wrapper padding (even when visual pill is smaller).
+ * - One-shot subtle pulse on first render in a session (honors prefers-reduced-motion).
+ * - Falls back to a "voir les sources" text link when any data field is missing.
+ *
+ * Tokens: uses `--afh-*` (ETNI-21) with `--country-*` fallback so this PR is
+ * independent. `SourceChainSheet` (ETNI-27) is intentionally NOT imported —
+ * callers wire the sheet via the `onOpen` callback.
+ */
+
+const SESSION_PULSE_KEY = "afh-chip-pulsed";
+
+export type ConfidenceChipVariant = "inline" | "hero" | "contested";
+
+export type ConfidenceChipProps = {
+  confidenceScore: number | null;
+  sourceCount: number | null;
+  lastHumanAuditAt: string | null; // ISO date (YYYY-MM-DD or full ISO)
+  variant?: ConfidenceChipVariant;
+  onOpen?: () => void;
+  ariaSuffix?: string;
+};
+
+function toIsoShortDate(value: string): string {
+  // Keep the leading YYYY-MM-DD slice from any ISO string.
+  return value.slice(0, 10);
+}
+
+function toLongFrenchDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export function ConfidenceChip({
+  confidenceScore,
+  sourceCount,
+  lastHumanAuditAt,
+  variant = "inline",
+  onOpen,
+  ariaSuffix,
+}: ConfidenceChipProps) {
+  const hasAllData =
+    confidenceScore !== null &&
+    confidenceScore !== undefined &&
+    sourceCount !== null &&
+    sourceCount !== undefined &&
+    lastHumanAuditAt !== null &&
+    lastHumanAuditAt !== undefined &&
+    lastHumanAuditAt !== "";
+
+  const [shouldPulse, setShouldPulse] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!hasAllData) return;
+    if (typeof window === "undefined") return;
+    try {
+      const alreadyPulsed = window.sessionStorage.getItem(SESSION_PULSE_KEY);
+      if (!alreadyPulsed) {
+        setShouldPulse(true);
+        window.sessionStorage.setItem(SESSION_PULSE_KEY, "1");
+      }
+    } catch {
+      // sessionStorage may throw in private mode — silently degrade (no pulse).
+    }
+  }, [hasAllData]);
+
+  // ---- Fallback: missing data → "voir les sources" text link.
+  if (!hasAllData) {
+    return (
+      <span className="inline-flex items-center p-1">
+        <a
+          href="#sources"
+          onClick={(event) => {
+            if (onOpen) {
+              event.preventDefault();
+              onOpen();
+            }
+          }}
+          className="text-sm underline underline-offset-2 text-[color:var(--afh-text-soft,var(--country-text-soft,#7A6B5D))] hover:text-[color:var(--afh-text,var(--country-text,#2C2018))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:var(--afh-focus,var(--country-text,#2C2018))]"
+        >
+          voir les sources
+        </a>
+      </span>
+    );
+  }
+
+  const shortDate = toIsoShortDate(lastHumanAuditAt!);
+  const longFrDate = toLongFrenchDate(lastHumanAuditAt!);
+  const pillText = `${confidenceScore} % · ${sourceCount} sources · vérifié ${shortDate}`;
+
+  const baseAriaLabel = `ouvrir la chaîne de sources pour cette assertion (confiance ${confidenceScore} %, ${sourceCount} sources, vérifiée le ${longFrDate})`;
+  const ariaLabel = ariaSuffix
+    ? `${baseAriaLabel} ${ariaSuffix}`
+    : baseAriaLabel;
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      if (onOpen) onOpen();
+    }
+  };
+
+  // Variant-specific typographic distinction — NO red, NO alarm.
+  // We only tune size, font-weight and emphasis. Colors stay neutral/earthy.
+  const variantClasses: Record<ConfidenceChipVariant, string> = {
+    inline:
+      "text-xs font-medium tracking-tight text-[color:var(--afh-text-soft,var(--country-text-soft,#7A6B5D))]",
+    hero: "text-sm font-semibold tracking-tight text-[color:var(--afh-text,var(--country-text,#2C2018))]",
+    contested:
+      "text-xs font-medium italic underline decoration-dotted underline-offset-4 text-[color:var(--afh-text-soft,var(--country-text-soft,#7A6B5D))]",
+  };
+
+  const pillBgClasses =
+    "bg-[color:var(--afh-conf-bg,var(--country-card,#FFFFFF))] border border-[color:var(--afh-border,var(--country-border,#E8DFD3))]";
+
+  return (
+    <span className="afh-chip-wrapper inline-flex items-center align-baseline p-2 -m-2">
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        onClick={() => {
+          if (onOpen) onOpen();
+        }}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          // Tap target: wrapper padding plus min sizing on the button itself.
+          "inline-flex items-center justify-center min-h-[28px] min-w-[28px] px-2 py-1 rounded-full",
+          "whitespace-nowrap select-none",
+          "transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+          "focus-visible:ring-[color:var(--afh-focus,var(--country-text,#2C2018))]",
+          pillBgClasses,
+          variantClasses[variant],
+          shouldPulse && "afh-chip-pulse"
+        )}
+        data-variant={variant}
+      >
+        <span className="afh-chip-text">{pillText}</span>
+      </button>
+
+      <style
+        // Inline keyframes for the one-shot pulse. Kept minimal and scoped via the
+        // `.afh-chip-pulse` class. `prefers-reduced-motion` neutralises the duration.
+        dangerouslySetInnerHTML={{
+          __html: `
+@keyframes afhChipPulse {
+  0% { box-shadow: 0 0 0 0 var(--afh-conf-pulse, rgba(184, 134, 11, 0.35)); }
+  70% { box-shadow: 0 0 0 6px var(--afh-conf-pulse-fade, rgba(184, 134, 11, 0)); }
+  100% { box-shadow: 0 0 0 0 var(--afh-conf-pulse-fade, rgba(184, 134, 11, 0)); }
+}
+.afh-chip-pulse {
+  animation: afhChipPulse var(--afh-motion-pulse, 1200ms) ease-out 1;
+}
+@media (prefers-reduced-motion: reduce) {
+  .afh-chip-pulse {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
+`,
+        }}
+      />
+    </span>
+  );
+}
+
+export default ConfidenceChip;

--- a/src/components/source-transparency/__tests__/ConfidenceChip.test.tsx
+++ b/src/components/source-transparency/__tests__/ConfidenceChip.test.tsx
@@ -4,10 +4,10 @@ import { ConfidenceChip } from "../ConfidenceChip";
 
 describe("ConfidenceChip", () => {
   beforeEach(() => {
-    // Clear sessionStorage between tests so the one-shot pulse logic is consistent.
     if (typeof sessionStorage !== "undefined") {
       sessionStorage.clear();
     }
+    document.getElementById("afh-chip-keyframes")?.remove();
   });
 
   describe("rendering with complete data", () => {
@@ -20,7 +20,6 @@ describe("ConfidenceChip", () => {
         />
       );
 
-      // Visible pill text — should contain the canonical separator and the ISO short date.
       expect(
         screen.getByText(/87\s*%\s*·\s*4\s*sources\s*·\s*vérifié\s*2025-09-21/i)
       ).toBeInTheDocument();
@@ -35,9 +34,7 @@ describe("ConfidenceChip", () => {
         />
       );
 
-      // No <svg> icons in the chip.
       expect(container.querySelector("svg")).toBeNull();
-      // No image either.
       expect(container.querySelector("img")).toBeNull();
     });
   });
@@ -53,16 +50,28 @@ describe("ConfidenceChip", () => {
       );
 
       const button = screen.getByRole("button");
-      // Long FR date for 2025-09-21 is "21 septembre 2025".
       expect(button).toHaveAttribute(
         "aria-label",
         "ouvrir la chaîne de sources pour cette assertion (confiance 87 %, 4 sources, vérifiée le 21 septembre 2025)"
       );
     });
+
+    it("renders the long French date in a TZ-stable way (no off-by-one)", () => {
+      render(
+        <ConfidenceChip
+          confidenceScore={87}
+          sourceCount={4}
+          lastHumanAuditAt="2025-09-21"
+        />
+      );
+
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-label")).toMatch(/21 septembre 2025/);
+    });
   });
 
   describe("keyboard interaction", () => {
-    it("invokes onOpen when Enter is pressed", () => {
+    it("invokes onOpen exactly once when activated (native click fired by Enter/Space)", () => {
       const onOpen = vi.fn();
       render(
         <ConfidenceChip
@@ -75,7 +84,9 @@ describe("ConfidenceChip", () => {
 
       const button = screen.getByRole("button");
       button.focus();
+      // Simulate the browser's native activation: keydown then click (no double-fire).
       fireEvent.keyDown(button, { key: "Enter" });
+      fireEvent.click(button);
 
       expect(onOpen).toHaveBeenCalledTimes(1);
     });
@@ -107,7 +118,6 @@ describe("ConfidenceChip", () => {
         />
       );
 
-      // No inline style or class should mention 'red' / 'destructive' / 'alarm'.
       const html = container.innerHTML.toLowerCase();
       expect(html).not.toMatch(/\bred\b/);
       expect(html).not.toMatch(/destructive/);
@@ -140,7 +150,6 @@ describe("ConfidenceChip", () => {
         />
       );
 
-      // It should be a link (anchor), not a chip button.
       expect(screen.queryByRole("button")).toBeNull();
       expect(screen.getByText(/voir les sources/i)).toBeInTheDocument();
     });
@@ -170,8 +179,8 @@ describe("ConfidenceChip", () => {
     });
   });
 
-  describe("tap target", () => {
-    it("wrapper has padding so the tap target is comfortable (>=44px via padding utility)", () => {
+  describe("tap target (WCAG 2.5.5 / 2.5.8)", () => {
+    it("button carries 44x44 min sizing utilities directly", () => {
       render(
         <ConfidenceChip
           confidenceScore={87}
@@ -180,12 +189,82 @@ describe("ConfidenceChip", () => {
         />
       );
 
-      // The button (the actual tappable element) must carry inline-min sizing/padding
-      // to guarantee a 44x44 tap target even when the visual pill is small.
       const button = screen.getByRole("button");
-      // We assert the class list mentions tap-padding utilities; we don't measure pixels in happy-dom.
       const classes = button.className;
-      expect(classes).toMatch(/min-h|min-w|p-/);
+      expect(classes).toContain("min-h-[44px]");
+      expect(classes).toContain("min-w-[44px]");
+    });
+  });
+
+  describe("per-chip session pulse", () => {
+    it("records the chip id in sessionStorage on first render", () => {
+      render(
+        <ConfidenceChip
+          id="chip-a"
+          confidenceScore={87}
+          sourceCount={4}
+          lastHumanAuditAt="2025-09-21"
+        />
+      );
+
+      const raw = sessionStorage.getItem("afh-chip-pulsed-ids");
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw!)).toContain("chip-a");
+    });
+
+    it("tracks distinct ids independently — each new chip id is added to the set", () => {
+      const { rerender } = render(
+        <ConfidenceChip
+          id="chip-a"
+          confidenceScore={87}
+          sourceCount={4}
+          lastHumanAuditAt="2025-09-21"
+        />
+      );
+      rerender(
+        <ConfidenceChip
+          id="chip-b"
+          confidenceScore={87}
+          sourceCount={4}
+          lastHumanAuditAt="2025-09-21"
+        />
+      );
+
+      const raw = sessionStorage.getItem("afh-chip-pulsed-ids");
+      expect(raw).not.toBeNull();
+      const ids = JSON.parse(raw!);
+      expect(ids).toContain("chip-a");
+      expect(ids).toContain("chip-b");
+    });
+  });
+
+  describe("keyframes injection", () => {
+    it("injects the keyframes <style> only once even with multiple chips", () => {
+      render(
+        <>
+          <ConfidenceChip
+            id="chip-1"
+            confidenceScore={87}
+            sourceCount={4}
+            lastHumanAuditAt="2025-09-21"
+          />
+          <ConfidenceChip
+            id="chip-2"
+            confidenceScore={87}
+            sourceCount={4}
+            lastHumanAuditAt="2025-09-21"
+          />
+          <ConfidenceChip
+            id="chip-3"
+            confidenceScore={87}
+            sourceCount={4}
+            lastHumanAuditAt="2025-09-21"
+          />
+        </>
+      );
+
+      const styles = document.querySelectorAll("style#afh-chip-keyframes");
+      expect(styles.length).toBe(1);
     });
   });
 });

--- a/src/components/source-transparency/__tests__/ConfidenceChip.test.tsx
+++ b/src/components/source-transparency/__tests__/ConfidenceChip.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfidenceChip } from "../ConfidenceChip";
+
+describe("ConfidenceChip", () => {
+  beforeEach(() => {
+    // Clear sessionStorage between tests so the one-shot pulse logic is consistent.
+    if (typeof sessionStorage !== "undefined") {
+      sessionStorage.clear();
+    }
+  });
+
+  describe("rendering with complete data", () => {
+    it("renders the typographic pill with confidence score, source count and audit date", () => {
+      render(
+        <ConfidenceChip
+          confidenceScore={87}
+          sourceCount={4}
+          lastHumanAuditAt="2025-09-21"
+        />
+      );
+
+      // Visible pill text — should contain the canonical separator and the ISO short date.
+      expect(
+        screen.getByText(/87\s*%\s*·\s*4\s*sources\s*·\s*vérifié\s*2025-09-21/i)
+      ).toBeInTheDocument();
+    });
+
+    it("renders no emoji or icon — only typographic content", () => {
+      const { container } = render(
+        <ConfidenceChip
+          confidenceScore={87}
+          sourceCount={4}
+          lastHumanAuditAt="2025-09-21"
+        />
+      );
+
+      // No <svg> icons in the chip.
+      expect(container.querySelector("svg")).toBeNull();
+      // No image either.
+      expect(container.querySelector("img")).toBeNull();
+    });
+  });
+
+  describe("aria-label", () => {
+    it("matches the exact French template using a long French date", () => {
+      render(
+        <ConfidenceChip
+          confidenceScore={87}
+          sourceCount={4}
+          lastHumanAuditAt="2025-09-21"
+        />
+      );
+
+      const button = screen.getByRole("button");
+      // Long FR date for 2025-09-21 is "21 septembre 2025".
+      expect(button).toHaveAttribute(
+        "aria-label",
+        "ouvrir la chaîne de sources pour cette assertion (confiance 87 %, 4 sources, vérifiée le 21 septembre 2025)"
+      );
+    });
+  });
+
+  describe("keyboard interaction", () => {
+    it("invokes onOpen when Enter is pressed", () => {
+      const onOpen = vi.fn();
+      render(
+        <ConfidenceChip
+          confidenceScore={87}
+          sourceCount={4}
+          lastHumanAuditAt="2025-09-21"
+          onOpen={onOpen}
+        />
+      );
+
+      const button = screen.getByRole("button");
+      button.focus();
+      fireEvent.keyDown(button, { key: "Enter" });
+
+      expect(onOpen).toHaveBeenCalledTimes(1);
+    });
+
+    it("invokes onOpen when the chip is clicked", () => {
+      const onOpen = vi.fn();
+      render(
+        <ConfidenceChip
+          confidenceScore={87}
+          sourceCount={4}
+          lastHumanAuditAt="2025-09-21"
+          onOpen={onOpen}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(onOpen).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("variant='contested'", () => {
+    it("renders without any red color or alarm styling", () => {
+      const { container } = render(
+        <ConfidenceChip
+          confidenceScore={42}
+          sourceCount={2}
+          lastHumanAuditAt="2025-09-21"
+          variant="contested"
+        />
+      );
+
+      // No inline style or class should mention 'red' / 'destructive' / 'alarm'.
+      const html = container.innerHTML.toLowerCase();
+      expect(html).not.toMatch(/\bred\b/);
+      expect(html).not.toMatch(/destructive/);
+      expect(html).not.toMatch(/alarm/);
+    });
+
+    it("still renders the canonical pill text in contested variant", () => {
+      render(
+        <ConfidenceChip
+          confidenceScore={42}
+          sourceCount={2}
+          lastHumanAuditAt="2025-09-21"
+          variant="contested"
+        />
+      );
+
+      expect(
+        screen.getByText(/42\s*%\s*·\s*2\s*sources\s*·\s*vérifié\s*2025-09-21/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("fallback when data is missing", () => {
+    it("renders a 'voir les sources' link when confidenceScore is null", () => {
+      render(
+        <ConfidenceChip
+          confidenceScore={null}
+          sourceCount={4}
+          lastHumanAuditAt="2025-09-21"
+        />
+      );
+
+      // It should be a link (anchor), not a chip button.
+      expect(screen.queryByRole("button")).toBeNull();
+      expect(screen.getByText(/voir les sources/i)).toBeInTheDocument();
+    });
+
+    it("renders a 'voir les sources' link when sourceCount is null", () => {
+      render(
+        <ConfidenceChip
+          confidenceScore={87}
+          sourceCount={null}
+          lastHumanAuditAt="2025-09-21"
+        />
+      );
+
+      expect(screen.getByText(/voir les sources/i)).toBeInTheDocument();
+    });
+
+    it("renders a 'voir les sources' link when lastHumanAuditAt is null", () => {
+      render(
+        <ConfidenceChip
+          confidenceScore={87}
+          sourceCount={4}
+          lastHumanAuditAt={null}
+        />
+      );
+
+      expect(screen.getByText(/voir les sources/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("tap target", () => {
+    it("wrapper has padding so the tap target is comfortable (>=44px via padding utility)", () => {
+      render(
+        <ConfidenceChip
+          confidenceScore={87}
+          sourceCount={4}
+          lastHumanAuditAt="2025-09-21"
+        />
+      );
+
+      // The button (the actual tappable element) must carry inline-min sizing/padding
+      // to guarantee a 44x44 tap target even when the visual pill is small.
+      const button = screen.getByRole("button");
+      // We assert the class list mentions tap-padding utilities; we don't measure pixels in happy-dom.
+      const classes = button.className;
+      expect(classes).toMatch(/min-h|min-w|p-/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- ETNI-25: tappable inline confidence chip for fiche assertions.
- New `src/components/source-transparency/ConfidenceChip.tsx` + tests + Storybook story.
- 3 variants (inline / hero / contested), all typographic (no red).
- Tap target ≥ 44×44 px via wrapper padding.
- Uses `--afh-*` tokens (ETNI-21) with `--country-*` fallback.

## Refined ACs covered

- Pill renders `X % · N sources · vérifié <long FR date>`.
- aria-label matches AC template verbatim.
- Enter/Space/Click invokes `onOpen` callback (sheet wiring done by caller).
- One-shot session pulse honoring `prefers-reduced-motion`.
- Missing data falls back to "voir les sources" text link.
- Storybook story for each variant + fallback.

## Out of scope

- Wiring into `SourceChainSheet` (caller provides `onOpen`).
- Fiche integration → follow-up.

## Test plan

- [x] `npx vitest run src/components/source-transparency/__tests__/ConfidenceChip.test.tsx` — 11/11 passing
- [x] `npm run type-check` — clean
- [ ] Storybook visual check at 430 / 720 / 1024 px

🤖 Generated with [Claude Code](https://claude.com/claude-code)
