### PR TITLE
ETNI-27: SourceChainSheet component

### DIFF
--- a/src/components/source-transparency/SourceChainSheet.lazy.tsx
+++ b/src/components/source-transparency/SourceChainSheet.lazy.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as React from "react";
+
+import type { SourceChainSheetProps } from "./SourceChainSheet";
+
+const LazyInner = React.lazy(() => import("./SourceChainSheet"));
+
+/**
+ * Lazy-loaded wrapper. Consumers should use this from fiche pages to keep the
+ * sheet bundle out of the initial chunk.
+ */
+export const LazySourceChainSheet: React.FC<SourceChainSheetProps> = (
+  props
+) => {
+  if (!props.open) return null;
+  return (
+    <React.Suspense fallback={null}>
+      <LazyInner {...props} />
+    </React.Suspense>
+  );
+};
+
+export default LazySourceChainSheet;

--- a/src/components/source-transparency/SourceChainSheet.stories.tsx
+++ b/src/components/source-transparency/SourceChainSheet.stories.tsx
@@ -1,0 +1,192 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as React from "react";
+
+import SourceChainSheet, {
+  type Source,
+  type SourceChainSheetProps,
+} from "./SourceChainSheet";
+
+const primarySource: Source = {
+  id: "s-primary-1",
+  title: "Atlas linguistique de l'Afrique de l'Ouest",
+  author: "Diop, M.",
+  year: 2019,
+  page: "p. 142",
+  url: "https://www.example.org/atlas-afrique-ouest",
+  tier: "primary",
+  brokenAt: null,
+};
+
+const secondarySource: Source = {
+  id: "s-secondary-1",
+  title: "Histoire générale de l'Afrique — Tome IV",
+  author: "UNESCO",
+  year: 1985,
+  page: "ch. 12",
+  url: "https://unesdoc.unesco.org/ark:/example",
+  tier: "secondary",
+  brokenAt: null,
+};
+
+const tertiarySource: Source = {
+  id: "s-tertiary-1",
+  title: "Wikipedia — Histoire du Sénégal",
+  url: "https://fr.wikipedia.org/wiki/Histoire_du_S%C3%A9n%C3%A9gal",
+  tier: "tertiary",
+  brokenAt: null,
+};
+
+const brokenSource: Source = {
+  id: "s-broken-1",
+  title: "Page institutionnelle disparue",
+  author: "Ministère de la Culture",
+  year: 2010,
+  url: "https://archive.example.gov/page-disparue",
+  tier: "secondary",
+  brokenAt: "2026-04-10",
+};
+
+const aiSource: Source = {
+  id: "s-ai-1",
+  title: "Synthèse générée par IA (validation humaine en attente)",
+  tier: "ai-enriched",
+  brokenAt: null,
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Wrapper to open the sheet on click — makes Storybook interactions nice    */
+/* -------------------------------------------------------------------------- */
+
+const Demo: React.FC<Omit<SourceChainSheetProps, "open" | "onOpenChange">> = (
+  props
+) => {
+  const [open, setOpen] = React.useState(true);
+  return (
+    <div className="min-h-[400px] p-4">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white"
+      >
+        Ouvrir la chaîne des sources
+      </button>
+      <SourceChainSheet {...props} open={open} onOpenChange={setOpen} />
+    </div>
+  );
+};
+
+/* -------------------------------------------------------------------------- */
+
+const meta: Meta<typeof Demo> = {
+  title: "SourceTransparency/SourceChainSheet",
+  component: Demo,
+  parameters: { layout: "fullscreen" },
+};
+
+export default meta;
+type Story = StoryObj<typeof Demo>;
+
+/* ----- Single position --------------------------------------------------- */
+
+export const SinglePosition: Story = {
+  args: {
+    anchorId: "chip-paragraph-1",
+    assertion: {
+      statement:
+        "Le peuple Seereer est historiquement attesté dans le bassin du Saloum dès le XIIIe siècle.",
+      confidenceScore: 0.84,
+      sourceCount: 3,
+      lastHumanAuditAt: "2026-04-01",
+    },
+    sources: [primarySource, secondarySource, tertiarySource],
+  },
+};
+
+/* ----- Multi-perspective (FR24) ------------------------------------------ */
+
+export const MultiPerspective: Story = {
+  args: {
+    anchorId: "chip-paragraph-7",
+    assertion: {
+      statement:
+        "L'origine du peuple est disputée par plusieurs courants historiographiques.",
+      confidenceScore: 0.55,
+      sourceCount: 4,
+      lastHumanAuditAt: "2026-03-15",
+    },
+    sources: [],
+    positions: [
+      {
+        position: "Hypothèse nilo-saharienne",
+        sources: [
+          { ...primarySource, id: "pos1-s1", title: "Étude linguistique 1972" },
+          { ...secondarySource, id: "pos1-s2", title: "Monographie 1988" },
+        ],
+      },
+      {
+        position: "Hypothèse bantoue méridionale",
+        sources: [
+          { ...primarySource, id: "pos2-s1", title: "Analyse génétique 2018" },
+          { ...tertiarySource, id: "pos2-s2", title: "Vue d'ensemble web" },
+        ],
+      },
+    ],
+  },
+};
+
+/* ----- Broken link ------------------------------------------------------- */
+
+export const BrokenLink: Story = {
+  args: {
+    anchorId: "chip-paragraph-broken",
+    assertion: {
+      statement:
+        "Le royaume cité disposait d'un système monétaire propre au XVIIIe siècle.",
+      confidenceScore: 0.62,
+      sourceCount: 2,
+      lastHumanAuditAt: null,
+    },
+    sources: [primarySource, brokenSource],
+    openFlagCount: 1,
+  },
+};
+
+/* ----- Missing data ------------------------------------------------------ */
+
+export const MissingData: Story = {
+  args: {
+    anchorId: "chip-paragraph-empty",
+    assertion: {
+      statement: "Assertion ajoutée par enrichissement IA, sans audit humain.",
+      confidenceScore: 0.35,
+      sourceCount: 1,
+      lastHumanAuditAt: null,
+    },
+    sources: [aiSource],
+  },
+};
+
+/* ----- Mobile viewport --------------------------------------------------- */
+
+export const Mobile: Story = {
+  args: SinglePosition.args,
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+};
+
+/* ----- Tablet viewport --------------------------------------------------- */
+
+export const Tablet: Story = {
+  args: SinglePosition.args,
+  parameters: { viewport: { defaultViewport: "tablet" } },
+};
+
+/* ----- Desktop viewport -------------------------------------------------- */
+
+export const Desktop: Story = {
+  args: {
+    ...SinglePosition.args,
+    openFlagCount: 2,
+    revisionUrl: "https://example.org/revision-history",
+  },
+  parameters: { viewport: { defaultViewport: "desktop" } },
+};

--- a/src/components/source-transparency/SourceChainSheet.tsx
+++ b/src/components/source-transparency/SourceChainSheet.tsx
@@ -1,0 +1,486 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+/* -------------------------------------------------------------------------- */
+/*  Types                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export type SourceTier = "primary" | "secondary" | "tertiary" | "ai-enriched";
+
+export type Source = {
+  id: string;
+  title: string;
+  author?: string;
+  year?: number;
+  page?: string;
+  url?: string;
+  tier: SourceTier;
+  /** ISO date string YYYY-MM-DD when the nightly health-check flagged the link. */
+  brokenAt?: string | null;
+};
+
+export type Assertion = {
+  statement: string;
+  position?: string;
+  confidenceScore: number;
+  sourceCount: number;
+  lastHumanAuditAt: string | null;
+};
+
+export type Revision = {
+  url: string;
+  label?: string;
+};
+
+export type PositionGroup = {
+  position: string;
+  sources: Source[];
+};
+
+export type SourceChainSheetProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  assertion: Assertion;
+  /** Flat source list when the assertion has a single position. Grouped by tier in UI. */
+  sources: Source[];
+  /** Multi-perspective grouping per FR24. When provided, takes precedence over `sources`. */
+  positions?: PositionGroup[];
+  openFlagCount?: number;
+  revisionUrl?: string;
+  /** Anchor id for the source chip (e.g. "chip-paragraph-3"). */
+  anchorId: string;
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Constants                                                                  */
+/* -------------------------------------------------------------------------- */
+
+const TIER_LABELS: Record<SourceTier, string> = {
+  primary: "Source primaire",
+  secondary: "Source secondaire",
+  tertiary: "Source tertiaire",
+  "ai-enriched": "Enrichi par IA",
+};
+
+const TIER_ORDER: SourceTier[] = [
+  "primary",
+  "secondary",
+  "tertiary",
+  "ai-enriched",
+];
+
+const CITE_DELAY_MS = 4000;
+
+/* -------------------------------------------------------------------------- */
+/*  Hooks                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Decides the responsive variant for the sheet:
+ *   - "bottom"           — viewport < 1024 px
+ *   - "right-narrow"     — 1024–1199 px (or tablet 720+) → 420 px wide
+ *   - "right-wide"       — ≥ 1200 px → 480 px wide
+ *
+ * Note: the AC says 720–1199 → right 420 and < 1024 → bottom. These overlap at
+ * 720–1023. The bottom-sheet rule wins because it is the stronger UX
+ * constraint (small height + swipe-down). Right-side variants only kick in
+ * from 1024 px upwards.
+ */
+function useSheetVariant(): "bottom" | "right-narrow" | "right-wide" {
+  const [variant, setVariant] = React.useState<
+    "bottom" | "right-narrow" | "right-wide"
+  >("bottom");
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+
+    const wide = window.matchMedia("(min-width: 1200px)");
+    const desktop = window.matchMedia("(min-width: 1024px)");
+
+    const compute = () => {
+      if (wide.matches) setVariant("right-wide");
+      else if (desktop.matches) setVariant("right-narrow");
+      else setVariant("bottom");
+    };
+
+    compute();
+    wide.addEventListener?.("change", compute);
+    desktop.addEventListener?.("change", compute);
+    return () => {
+      wide.removeEventListener?.("change", compute);
+      desktop.removeEventListener?.("change", compute);
+    };
+  }, []);
+
+  return variant;
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener?.("change", update);
+    return () => mq.removeEventListener?.("change", update);
+  }, []);
+
+  return reduced;
+}
+
+/**
+ * Syncs the sheet open state with the URL hash so the anchor (#chip-...)
+ * survives page refreshes and is shareable.
+ */
+function useUrlAnchorSync(
+  open: boolean,
+  anchorId: string,
+  onOpenChange: (open: boolean) => void
+) {
+  // Read the initial hash and open the sheet if it matches.
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const currentHash = window.location.hash.replace(/^#/, "");
+    if (currentHash === anchorId && !open) {
+      onOpenChange(true);
+    }
+    // Intentionally run only once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Write the hash when the sheet opens / closes.
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const { pathname, search } = window.location;
+    const target = open
+      ? `${pathname}${search}#${anchorId}`
+      : `${pathname}${search}`;
+    try {
+      window.history.replaceState(null, "", target);
+    } catch {
+      /* no-op in tests */
+    }
+  }, [open, anchorId]);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Helpers                                                                    */
+/* -------------------------------------------------------------------------- */
+
+function groupByTier(sources: Source[]): Record<SourceTier, Source[]> {
+  const out: Record<SourceTier, Source[]> = {
+    primary: [],
+    secondary: [],
+    tertiary: [],
+    "ai-enriched": [],
+  };
+  for (const s of sources) {
+    out[s.tier].push(s);
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Sub-components                                                             */
+/* -------------------------------------------------------------------------- */
+
+function SourceItem({ source }: { source: Source }) {
+  const isBroken = Boolean(source.brokenAt);
+
+  return (
+    <li
+      data-testid={`source-item-${source.id}`}
+      className="space-y-1 rounded-md border border-[var(--afh-border,var(--country-border,#e5e7eb))] bg-[var(--afh-surface,var(--country-surface,#fff))] p-3"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-medium text-[var(--afh-fg,var(--country-fg,#111827))]">
+          {source.title}
+        </p>
+        <span
+          data-testid={`source-tier-${source.id}`}
+          className="shrink-0 rounded-full bg-[var(--afh-muted,var(--country-muted,#f3f4f6))] px-2 py-0.5 text-xs font-medium text-[var(--afh-fg-muted,var(--country-fg-muted,#6b7280))]"
+        >
+          {TIER_LABELS[source.tier]}
+        </span>
+      </div>
+      <p className="text-xs text-[var(--afh-fg-muted,var(--country-fg-muted,#6b7280))]">
+        {[source.author, source.year, source.page].filter(Boolean).join(" · ")}
+      </p>
+      {source.url ? (
+        <a
+          data-testid={`source-url-${source.id}`}
+          href={source.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            "inline-block break-all text-xs underline underline-offset-2",
+            isBroken
+              ? "line-through text-[var(--afh-fg-muted,var(--country-fg-muted,#9ca3af))]"
+              : "text-[var(--afh-accent,var(--country-accent,#1d4ed8))]"
+          )}
+        >
+          {source.url}
+        </a>
+      ) : null}
+      {isBroken ? (
+        <span
+          data-testid={`source-broken-badge-${source.id}`}
+          className="inline-flex items-center rounded-full bg-[var(--afh-warn-bg,#fef3c7)] px-2 py-0.5 text-[11px] font-medium text-[var(--afh-warn-fg,#92400e)]"
+        >
+          lien non résolu — signalé {source.brokenAt}
+        </span>
+      ) : null}
+    </li>
+  );
+}
+
+function TierGroup({ tier, sources }: { tier: SourceTier; sources: Source[] }) {
+  if (sources.length === 0) return null;
+  return (
+    <div data-testid={`tier-group-${tier}`} className="space-y-2">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-[var(--afh-fg-muted,var(--country-fg-muted,#6b7280))]">
+        {TIER_LABELS[tier]}
+      </h4>
+      <ul className="space-y-2">
+        {sources.map((s) => (
+          <SourceItem key={s.id} source={s} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SourceList({ sources }: { sources: Source[] }) {
+  const grouped = groupByTier(sources);
+  return (
+    <div className="space-y-4">
+      {TIER_ORDER.map((tier) => (
+        <TierGroup key={tier} tier={tier} sources={grouped[tier]} />
+      ))}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Main component                                                             */
+/* -------------------------------------------------------------------------- */
+
+const SourceChainSheet: React.FC<SourceChainSheetProps> = ({
+  open,
+  onOpenChange,
+  assertion,
+  sources,
+  positions,
+  openFlagCount = 0,
+  revisionUrl,
+  anchorId,
+}) => {
+  const variant = useSheetVariant();
+  const reducedMotion = usePrefersReducedMotion();
+  useUrlAnchorSync(open, anchorId, onOpenChange);
+
+  // "Cite this assertion" appears after a 4 s dwell.
+  const [showCite, setShowCite] = React.useState(false);
+  React.useEffect(() => {
+    if (!open) {
+      setShowCite(false);
+      return;
+    }
+    const t = setTimeout(() => setShowCite(true), CITE_DELAY_MS);
+    return () => clearTimeout(t);
+  }, [open]);
+
+  const statementId = `${anchorId}-statement`;
+
+  const side: "bottom" | "right" = variant === "bottom" ? "bottom" : "right";
+
+  const widthClass =
+    variant === "right-wide"
+      ? "sm:max-w-[480px] w-[480px]"
+      : variant === "right-narrow"
+        ? "sm:max-w-[420px] w-[420px]"
+        : "w-full max-h-[85vh] overflow-y-auto";
+
+  const motionStyle: React.CSSProperties = reducedMotion
+    ? { animationDuration: "0.01ms" }
+    : {};
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side={side}
+        className={cn("flex flex-col gap-4", widthClass)}
+        style={motionStyle}
+        aria-labelledby={statementId}
+        aria-modal="true"
+        data-reduced-motion={reducedMotion ? "true" : "false"}
+        data-variant={variant}
+      >
+        {/* Visually hidden title/description for radix a11y */}
+        <SheetTitle className="sr-only">Chaîne des sources</SheetTitle>
+        <SheetDescription className="sr-only">
+          Détails de l&apos;assertion, niveau de confiance et sources
+          vérifiables.
+        </SheetDescription>
+
+        {/* 1. Assertion */}
+        <section
+          data-testid="section-assertion"
+          className="border-l-4 border-[var(--afh-accent,var(--country-accent,#1d4ed8))] pl-3"
+        >
+          <h3
+            id={statementId}
+            className="font-serif text-base italic text-[var(--afh-fg,var(--country-fg,#111827))]"
+          >
+            « {assertion.statement} »
+          </h3>
+          {assertion.position ? (
+            <p className="mt-1 text-xs text-[var(--afh-fg-muted,var(--country-fg-muted,#6b7280))]">
+              Position : {assertion.position}
+            </p>
+          ) : null}
+        </section>
+
+        {/* 2. Confidence */}
+        <section
+          data-testid="section-confidence"
+          className="rounded-md bg-[var(--afh-muted,var(--country-muted,#f9fafb))] p-3"
+        >
+          <div className="flex items-baseline justify-between">
+            <span className="text-xs font-semibold uppercase tracking-wide text-[var(--afh-fg-muted,var(--country-fg-muted,#6b7280))]">
+              Niveau de confiance
+            </span>
+            <span className="text-lg font-semibold text-[var(--afh-fg,var(--country-fg,#111827))]">
+              {Math.round(assertion.confidenceScore * 100)}%
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-[var(--afh-fg-muted,var(--country-fg-muted,#6b7280))]">
+            Calculé à partir de {assertion.sourceCount} source
+            {assertion.sourceCount > 1 ? "s" : ""}
+            {assertion.lastHumanAuditAt
+              ? ` · dernier audit humain le ${assertion.lastHumanAuditAt}`
+              : " · jamais audité par un humain"}
+            .
+          </p>
+        </section>
+
+        {/* 3. Flags banner (conditional) */}
+        {openFlagCount > 0 ? (
+          <section
+            data-testid="section-flags"
+            role="status"
+            className="rounded-md border border-[var(--afh-warn-fg,#92400e)]/30 bg-[var(--afh-warn-bg,#fef3c7)] p-3 text-sm text-[var(--afh-warn-fg,#92400e)]"
+          >
+            {openFlagCount} signalement{openFlagCount > 1 ? "s" : ""} ouvert
+            {openFlagCount > 1 ? "s" : ""} sur cette assertion.
+          </section>
+        ) : null}
+
+        {/* 4. Sources */}
+        <section data-testid="section-sources" className="space-y-4">
+          <h3 className="text-sm font-semibold text-[var(--afh-fg,var(--country-fg,#111827))]">
+            Sources
+          </h3>
+          {positions && positions.length > 0 ? (
+            <div className="space-y-4">
+              {positions.map((pg, idx) => (
+                <div
+                  key={`${pg.position}-${idx}`}
+                  data-testid={`position-group-${idx}`}
+                  className="space-y-2 rounded-md border border-dashed border-[var(--afh-border,var(--country-border,#e5e7eb))] p-3"
+                >
+                  <p className="text-xs font-semibold text-[var(--afh-accent,var(--country-accent,#1d4ed8))]">
+                    {pg.position}
+                  </p>
+                  <SourceList sources={pg.sources} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <SourceList sources={sources} />
+          )}
+        </section>
+
+        {/* 5. Revision link (conditional) */}
+        {revisionUrl ? (
+          <section data-testid="section-revision">
+            <a
+              href={revisionUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs underline underline-offset-2 text-[var(--afh-accent,var(--country-accent,#1d4ed8))]"
+            >
+              Voir l&apos;historique des révisions
+            </a>
+          </section>
+        ) : null}
+
+        {/* 6. FlagTarget shell — wired in Epic 2 */}
+        <section data-testid="section-flag-target" className="pt-2">
+          {/* TODO(etni-flag): wire FlagTarget */}
+          <button
+            type="button"
+            disabled
+            className="w-full rounded-md border border-dashed border-[var(--afh-border,var(--country-border,#e5e7eb))] px-3 py-2 text-xs text-[var(--afh-fg-muted,var(--country-fg-muted,#9ca3af))]"
+            aria-label="Signaler un problème — bientôt disponible"
+          >
+            Signaler un problème (bientôt disponible)
+          </button>
+        </section>
+
+        {/* 7. Cite affordance (appears after 4 s dwell) */}
+        <section data-testid="section-cite" className="pt-1">
+          <button
+            type="button"
+            aria-hidden={!showCite}
+            tabIndex={showCite ? 0 : -1}
+            className={cn(
+              "text-xs underline underline-offset-2 transition-opacity",
+              reducedMotion ? "duration-[1ms]" : "duration-300",
+              showCite ? "opacity-100" : "pointer-events-none opacity-0"
+            )}
+          >
+            Citer cette assertion
+          </button>
+        </section>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+SourceChainSheet.displayName = "SourceChainSheet";
+
+export default SourceChainSheet;
+
+/* -------------------------------------------------------------------------- */
+/*  Lazy wrapper for code-splitting                                            */
+/* -------------------------------------------------------------------------- */
+
+const LazyInner = React.lazy(() => import("./SourceChainSheet"));
+
+/**
+ * Lazy-loaded wrapper. Consumers should use this from fiche pages to keep the
+ * sheet bundle out of the initial chunk.
+ */
+export const LazySourceChainSheet: React.FC<SourceChainSheetProps> = (
+  props
+) => {
+  // Only mount the lazy chunk once the consumer has indicated intent to open.
+  if (!props.open) return null;
+  return (
+    <React.Suspense fallback={null}>
+      <LazyInner {...props} />
+    </React.Suspense>
+  );
+};

--- a/src/components/source-transparency/SourceChainSheet.tsx
+++ b/src/components/source-transparency/SourceChainSheet.tsx
@@ -80,6 +80,13 @@ const TIER_ORDER: SourceTier[] = [
 
 const CITE_DELAY_MS = 4000;
 
+/**
+ * Tracks anchors that have already been auto-opened by URL-hash on first mount,
+ * so that mounting multiple `SourceChainSheet` instances on the same fiche
+ * doesn't open every one of them when the user follows a shareable link.
+ */
+const openedAnchors = new Set<string>();
+
 /* -------------------------------------------------------------------------- */
 /*  Hooks                                                                      */
 /* -------------------------------------------------------------------------- */
@@ -149,10 +156,14 @@ function useUrlAnchorSync(
   onOpenChange: (open: boolean) => void
 ) {
   // Read the initial hash and open the sheet if it matches.
+  // Guard with a module-level registry so only the first mount per anchorId
+  // triggers the auto-open — multiple sheets with the same anchor must not
+  // all open at once.
   React.useEffect(() => {
     if (typeof window === "undefined") return;
     const currentHash = window.location.hash.replace(/^#/, "");
-    if (currentHash === anchorId && !open) {
+    if (currentHash === anchorId && !open && !openedAnchors.has(anchorId)) {
+      openedAnchors.add(anchorId);
       onOpenChange(true);
     }
     // Intentionally run only once on mount.
@@ -160,16 +171,29 @@ function useUrlAnchorSync(
   }, []);
 
   // Write the hash when the sheet opens / closes.
+  // Per-anchor guard: only rewrite the URL when the current hash is empty or
+  // already matches this instance's anchor. Without this guard, mounting
+  // multiple sheets on one fiche would strip an unrelated hash on every
+  // open/close cycle.
   React.useEffect(() => {
     if (typeof window === "undefined") return;
-    const { pathname, search } = window.location;
-    const target = open
-      ? `${pathname}${search}#${anchorId}`
-      : `${pathname}${search}`;
-    try {
-      window.history.replaceState(null, "", target);
-    } catch {
-      /* no-op in tests */
+    const { pathname, search, hash } = window.location;
+    if (open) {
+      if (hash === `#${anchorId}` || hash === "") {
+        const target = `${pathname}${search}#${anchorId}`;
+        try {
+          window.history.replaceState(null, "", target);
+        } catch {
+          /* no-op in tests */
+        }
+      }
+    } else if (hash === `#${anchorId}`) {
+      const target = `${pathname}${search}`;
+      try {
+        window.history.replaceState(null, "", target);
+      } catch {
+        /* no-op in tests */
+      }
     }
   }, [open, anchorId]);
 }
@@ -191,12 +215,53 @@ function groupByTier(sources: Source[]): Record<SourceTier, Source[]> {
   return out;
 }
 
+/**
+ * Returns the URL only if it parses to an `http:` or `https:` scheme.
+ * Defends against `javascript:` or `data:` schemes coming from contributor
+ * sources. Returns `null` otherwise (including for malformed URLs).
+ */
+export function safeUrl(raw: string | undefined | null): string | null {
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const FR_DATE_FORMATTER = new Intl.DateTimeFormat("fr-FR", {
+  dateStyle: "long",
+});
+
+/**
+ * Formats an ISO date (YYYY-MM-DD) as a long French date. Uses a TZ-stable
+ * parser to avoid off-by-one errors on date-only inputs. Returns the raw
+ * input on parse failure.
+ */
+export function formatBrokenDate(iso: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (!match) return iso;
+  const [, yearStr, monthStr, dayStr] = match;
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  const date = new Date(year, month - 1, day);
+  if (Number.isNaN(date.getTime())) return iso;
+  return FR_DATE_FORMATTER.format(date);
+}
+
 /* -------------------------------------------------------------------------- */
 /*  Sub-components                                                             */
 /* -------------------------------------------------------------------------- */
 
 function SourceItem({ source }: { source: Source }) {
   const isBroken = Boolean(source.brokenAt);
+  const sanitizedUrl = safeUrl(source.url);
+  const renderAsLink = !isBroken && sanitizedUrl !== null;
 
   return (
     <li
@@ -218,27 +283,35 @@ function SourceItem({ source }: { source: Source }) {
         {[source.author, source.year, source.page].filter(Boolean).join(" · ")}
       </p>
       {source.url ? (
-        <a
-          data-testid={`source-url-${source.id}`}
-          href={source.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={cn(
-            "inline-block break-all text-xs underline underline-offset-2",
-            isBroken
-              ? "line-through text-[var(--afh-fg-muted,var(--country-fg-muted,#9ca3af))]"
-              : "text-[var(--afh-accent,var(--country-accent,#1d4ed8))]"
-          )}
-        >
-          {source.url}
-        </a>
+        renderAsLink ? (
+          <a
+            data-testid={`source-url-${source.id}`}
+            href={sanitizedUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block break-all text-xs underline underline-offset-2 text-[var(--afh-accent,var(--country-accent,#1d4ed8))]"
+          >
+            {source.url}
+          </a>
+        ) : (
+          <span
+            data-testid={`source-url-${source.id}`}
+            aria-disabled="true"
+            className={cn(
+              "inline-block break-all text-xs underline underline-offset-2 text-[var(--afh-fg-muted,var(--country-fg-muted,#9ca3af))]",
+              isBroken && "line-through"
+            )}
+          >
+            {source.url}
+          </span>
+        )
       ) : null}
-      {isBroken ? (
+      {isBroken && source.brokenAt ? (
         <span
           data-testid={`source-broken-badge-${source.id}`}
           className="inline-flex items-center rounded-full bg-[var(--afh-warn-bg,#fef3c7)] px-2 py-0.5 text-[11px] font-medium text-[var(--afh-warn-fg,#92400e)]"
         >
-          lien non résolu — signalé {source.brokenAt}
+          lien non résolu — signalé le {formatBrokenDate(source.brokenAt)}
         </span>
       ) : null}
     </li>
@@ -413,10 +486,10 @@ const SourceChainSheet: React.FC<SourceChainSheetProps> = ({
         </section>
 
         {/* 5. Revision link (conditional) */}
-        {revisionUrl ? (
+        {revisionUrl && safeUrl(revisionUrl) ? (
           <section data-testid="section-revision">
             <a
-              href={revisionUrl}
+              href={safeUrl(revisionUrl) as string}
               target="_blank"
               rel="noopener noreferrer"
               className="text-xs underline underline-offset-2 text-[var(--afh-accent,var(--country-accent,#1d4ed8))]"
@@ -462,25 +535,3 @@ const SourceChainSheet: React.FC<SourceChainSheetProps> = ({
 SourceChainSheet.displayName = "SourceChainSheet";
 
 export default SourceChainSheet;
-
-/* -------------------------------------------------------------------------- */
-/*  Lazy wrapper for code-splitting                                            */
-/* -------------------------------------------------------------------------- */
-
-const LazyInner = React.lazy(() => import("./SourceChainSheet"));
-
-/**
- * Lazy-loaded wrapper. Consumers should use this from fiche pages to keep the
- * sheet bundle out of the initial chunk.
- */
-export const LazySourceChainSheet: React.FC<SourceChainSheetProps> = (
-  props
-) => {
-  // Only mount the lazy chunk once the consumer has indicated intent to open.
-  if (!props.open) return null;
-  return (
-    <React.Suspense fallback={null}>
-      <LazyInner {...props} />
-    </React.Suspense>
-  );
-};

--- a/src/components/source-transparency/__tests__/SourceChainSheet.test.tsx
+++ b/src/components/source-transparency/__tests__/SourceChainSheet.test.tsx
@@ -131,8 +131,37 @@ describe("SourceChainSheet", () => {
     const link = screen.getByTestId("source-url-src-1");
     expect(link.className).toMatch(/line-through/);
     expect(screen.getByTestId("source-broken-badge-src-1")).toHaveTextContent(
-      /lien non résolu — signalé 2026-04-10/i
+      /lien non résolu — signalé le 10 avril 2026/i
     );
+  });
+
+  it("renders broken-link URL as a span (not an anchor) to prevent navigation", () => {
+    renderSheet({
+      sources: [
+        {
+          ...baseSource,
+          brokenAt: "2026-04-10",
+        },
+      ],
+    });
+    const el = screen.getByTestId("source-url-src-1");
+    expect(el.tagName.toLowerCase()).toBe("span");
+    expect(el).toHaveAttribute("aria-disabled", "true");
+    expect(el).not.toHaveAttribute("href");
+  });
+
+  it("renders javascript: URLs as a plain span (safeUrl guard)", () => {
+    renderSheet({
+      sources: [
+        {
+          ...baseSource,
+          url: "javascript:alert('xss')",
+        },
+      ],
+    });
+    const el = screen.getByTestId("source-url-src-1");
+    expect(el.tagName.toLowerCase()).toBe("span");
+    expect(el).not.toHaveAttribute("href");
   });
 
   it("calls onOpenChange(false) when Escape is pressed", () => {
@@ -205,5 +234,39 @@ describe("SourceChainSheet", () => {
   it("returns null when open is false", () => {
     const { container } = renderSheet({ open: false });
     expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("opens only the first sheet instance when the URL hash matches the anchor", async () => {
+    window.history.replaceState(null, "", "/?#chip-shared");
+    const onOpenChangeA = vi.fn();
+    const onOpenChangeB = vi.fn();
+    const propsBase: Omit<SourceChainSheetProps, "onOpenChange"> = {
+      open: false,
+      assertion: {
+        statement: "shared",
+        confidenceScore: 0.5,
+        sourceCount: 1,
+        lastHumanAuditAt: null,
+      },
+      sources: [baseSource],
+      anchorId: "chip-shared",
+    };
+    render(
+      <>
+        <SourceChainSheet {...propsBase} onOpenChange={onOpenChangeA} />
+        <SourceChainSheet {...propsBase} onOpenChange={onOpenChangeB} />
+      </>
+    );
+    expect(onOpenChangeA).toHaveBeenCalledWith(true);
+    expect(onOpenChangeB).not.toHaveBeenCalled();
+    window.history.replaceState(null, "", "/");
+  });
+});
+
+describe("LazySourceChainSheet", () => {
+  it("imports cleanly from the dedicated lazy file", async () => {
+    const mod = await import("../SourceChainSheet.lazy");
+    expect(mod.LazySourceChainSheet).toBeDefined();
+    expect(typeof mod.LazySourceChainSheet).toBe("function");
   });
 });

--- a/src/components/source-transparency/__tests__/SourceChainSheet.test.tsx
+++ b/src/components/source-transparency/__tests__/SourceChainSheet.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+  cleanup,
+} from "@testing-library/react";
+import SourceChainSheet, {
+  type Source,
+  type SourceChainSheetProps,
+} from "../SourceChainSheet";
+
+const baseSource: Source = {
+  id: "src-1",
+  title: "Atlas linguistique de l'Afrique",
+  author: "M. Diop",
+  year: 2021,
+  page: "p. 42",
+  url: "https://example.org/atlas",
+  tier: "primary",
+  brokenAt: null,
+};
+
+const renderSheet = (override: Partial<SourceChainSheetProps> = {}) => {
+  const onOpenChange = vi.fn();
+  const props: SourceChainSheetProps = {
+    open: true,
+    onOpenChange,
+    assertion: {
+      statement: "Le peuple Seereer est attesté depuis le XIIIe siècle.",
+      position: undefined,
+      confidenceScore: 0.82,
+      sourceCount: 3,
+      lastHumanAuditAt: "2026-04-01",
+    },
+    sources: [baseSource],
+    anchorId: "chip-paragraph-3",
+    ...override,
+  };
+  const utils = render(<SourceChainSheet {...props} />);
+  return { ...utils, onOpenChange, props };
+};
+
+beforeEach(() => {
+  // Default to desktop viewport for matchMedia
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SourceChainSheet", () => {
+  it("renders a dialog with role and aria-modal", () => {
+    renderSheet();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("uses aria-labelledby pointing to the assertion statement", () => {
+    renderSheet();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute(
+      "aria-labelledby",
+      "chip-paragraph-3-statement"
+    );
+    const statement = document.getElementById("chip-paragraph-3-statement");
+    expect(statement).not.toBeNull();
+    expect(statement?.textContent).toContain("Seereer");
+  });
+
+  it("renders sections in strict order", () => {
+    renderSheet({
+      openFlagCount: 2,
+      revisionUrl: "https://example.org/revision",
+    });
+    const sections = screen.getAllByTestId(/^section-/);
+    const order = sections.map((el) => el.getAttribute("data-testid"));
+    expect(order).toEqual([
+      "section-assertion",
+      "section-confidence",
+      "section-flags",
+      "section-sources",
+      "section-revision",
+      "section-flag-target",
+      "section-cite",
+    ]);
+  });
+
+  it("does not render the flag banner when no open flags", () => {
+    renderSheet({ openFlagCount: 0 });
+    expect(screen.queryByTestId("section-flags")).toBeNull();
+  });
+
+  it("does not render the revision link when revisionUrl is missing", () => {
+    renderSheet();
+    expect(screen.queryByTestId("section-revision")).toBeNull();
+  });
+
+  it("renders a disabled FlagTarget shell button", () => {
+    renderSheet();
+    const flagTarget = screen.getByTestId("section-flag-target");
+    const btn = within(flagTarget).getByRole("button");
+    expect(btn).toBeDisabled();
+  });
+
+  it("renders broken-link sources with line-through URL and a calm badge", () => {
+    renderSheet({
+      sources: [
+        {
+          ...baseSource,
+          brokenAt: "2026-04-10",
+        },
+      ],
+    });
+    const link = screen.getByTestId("source-url-src-1");
+    expect(link.className).toMatch(/line-through/);
+    expect(screen.getByTestId("source-broken-badge-src-1")).toHaveTextContent(
+      /lien non résolu — signalé 2026-04-10/i
+    );
+  });
+
+  it("calls onOpenChange(false) when Escape is pressed", () => {
+    const { onOpenChange } = renderSheet();
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("renders multi-position positions as separate source lists", () => {
+    renderSheet({
+      positions: [
+        {
+          position: "Origine nilotique",
+          sources: [{ ...baseSource, id: "src-a", title: "Source A" }],
+        },
+        {
+          position: "Origine bantoue",
+          sources: [
+            {
+              ...baseSource,
+              id: "src-b",
+              title: "Source B",
+              tier: "secondary",
+            },
+          ],
+        },
+      ],
+      sources: [],
+    });
+    const sourcesSection = screen.getByTestId("section-sources");
+    const positionGroups =
+      within(sourcesSection).getAllByTestId(/^position-group-/);
+    expect(positionGroups).toHaveLength(2);
+    expect(positionGroups[0]).toHaveTextContent("Origine nilotique");
+    expect(positionGroups[0]).toHaveTextContent("Source A");
+    expect(positionGroups[1]).toHaveTextContent("Origine bantoue");
+    expect(positionGroups[1]).toHaveTextContent("Source B");
+  });
+
+  it("groups single-list sources by tier", () => {
+    renderSheet({
+      sources: [
+        { ...baseSource, id: "p1", tier: "primary", title: "Primary src" },
+        { ...baseSource, id: "s1", tier: "secondary", title: "Secondary src" },
+        { ...baseSource, id: "t1", tier: "tertiary", title: "Tertiary src" },
+        { ...baseSource, id: "a1", tier: "ai-enriched", title: "AI src" },
+      ],
+    });
+    const sourcesSection = screen.getByTestId("section-sources");
+    expect(
+      within(sourcesSection).getByTestId("tier-group-primary")
+    ).toBeInTheDocument();
+    expect(
+      within(sourcesSection).getByTestId("tier-group-secondary")
+    ).toBeInTheDocument();
+    expect(
+      within(sourcesSection).getByTestId("tier-group-tertiary")
+    ).toBeInTheDocument();
+    expect(
+      within(sourcesSection).getByTestId("tier-group-ai-enriched")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the confidence block with the score", () => {
+    renderSheet();
+    const confidence = screen.getByTestId("section-confidence");
+    expect(confidence).toHaveTextContent("82");
+  });
+
+  it("returns null when open is false", () => {
+    const { container } = renderSheet({ open: false });
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- ETNI-27: lazy-loaded `SourceChainSheet` opening from `ConfidenceChip`.
- New `src/components/source-transparency/SourceChainSheet.tsx` + tests + Storybook story.
- Composes existing shadcn `Sheet` primitive; responsive variants (bottom < 1024 / 420 px 720–1199 / 480 px ≥ 1200).

## Refined ACs covered

- Strict 7-section order (assertion / confidence / flags / sources by tier / revision / FlagTarget shell / cite affordance).
- FR24 multi-perspective via `positions` array.
- Broken-link rendering: line-through URL + "lien non résolu — signalé DATE" badge.
- a11y: role=dialog + focus trap + inert background + aria-labelledby.
- URL anchor state for shareable open sheet.
- Lazy-loaded via `React.lazy` for code-splitting.
- Honors `prefers-reduced-motion`.

## Out of scope (deferred)

- `FlagTarget` is rendered as a disabled shell button; Epic 2 will wire the real component.
- Fiche integration → follow-up PR.

## Test plan

- [x] `npx vitest run src/components/source-transparency/__tests__/SourceChainSheet.test.tsx`
- [x] `npm run type-check`
- [ ] Storybook visual check at 430 / 720 / 1024 / 1280 px
