### PR TITLE
ETNI-21: design-system tokens + typography foundation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,12 +13,47 @@
 // `@next/next/no-html-link-for-anchor` and the full `@next/next` plugin rule
 // set.  No Next.js rules are lost; only the `next lint` wrapper is bypassed.
 // -----------------------------------------------------------------------------
+import { createRequire } from "node:module";
 import nextConfig from "eslint-config-next";
 import tsConfig from "eslint-config-next/typescript";
+
+// ETNI-21: load the Africa History plugin (CommonJS, lives under eslint/).
+const require = createRequire(import.meta.url);
+const afhPlugin = require("./eslint/plugins/afh.js");
 
 const eslintConfig = [
   ...nextConfig,
   ...tsConfig,
+
+  // ETNI-21: ESLint custom-rule sources must remain CommonJS (the ESLint
+  // plugin API is CJS). Globally ignore them so we don't fight no-require-imports.
+  {
+    ignores: ["eslint/**"],
+  },
+
+  // ===========================================================================
+  // ETNI-21 / UX-DR49 rule 3: --afh-error misuse detector
+  // ---------------------------------------------------------------------------
+  // The `--afh-error` token is reserved for components whose filename signals
+  // an error / invalid / broken context. The rule fires elsewhere to keep the
+  // design-system warning vocabulary unambiguous.
+  // ===========================================================================
+  {
+    files: [
+      "src/components/**/*.{ts,tsx,js,jsx}",
+      "src/app/**/*.{ts,tsx,js,jsx}",
+    ],
+    ignores: [
+      "**/*.stories.*",
+      "**/*.test.*",
+      "**/__tests__/**",
+      "**/*.mdx",
+    ],
+    plugins: { afh: afhPlugin },
+    rules: {
+      "afh/afh-error-misuse": "error",
+    },
+  },
 
   // =============================================================================
   // NFR33, AR28: Enforce structured logging via @/lib/api/logger

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,9 +26,15 @@ const eslintConfig = [
   ...tsConfig,
 
   // ETNI-21: ESLint custom-rule sources must remain CommonJS (the ESLint
-  // plugin API is CJS). Globally ignore them so we don't fight no-require-imports.
+  // plugin API is CJS). Scope the no-require-imports relaxation to these
+  // files only — the files themselves still get parsed and linted for
+  // every other rule (we just allow `require(...)` here).
   {
-    ignores: ["eslint/**"],
+    files: ["eslint/**/*.{js,cjs,mjs,ts}"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+      "@typescript-eslint/no-var-requires": "off",
+    },
   },
 
   // ===========================================================================

--- a/eslint/__tests__/afh-error-misuse.test.js
+++ b/eslint/__tests__/afh-error-misuse.test.js
@@ -1,0 +1,77 @@
+/**
+ * Unit test for the `afh/afh-error-misuse` ESLint rule (ETNI-21).
+ *
+ * Uses ESLint's official `RuleTester` so it stays current with the
+ * resolver behaviour of the host project (ESLint v9 flat config).
+ */
+
+"use strict";
+
+const { RuleTester } = require("eslint");
+const rule = require("../rules/afh-error-misuse.js");
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+ruleTester.run("afh/afh-error-misuse", rule, {
+  valid: [
+    {
+      // Component file IS an Error component — `--afh-error` is fair game.
+      name: "Allowed in ErrorState.tsx",
+      code: `const style = { color: "var(--afh-error)" };`,
+      filename: "src/components/ErrorState.tsx",
+    },
+    {
+      name: "Allowed in InvalidInput.tsx",
+      code: `const style = { background: "var(--afh-error-bg)" };`,
+      filename: "src/components/InvalidInput.tsx",
+    },
+    {
+      name: "Allowed in BrokenLinkBanner.tsx",
+      code: 'const cls = "bg-afh-error text-white";',
+      filename: "src/components/BrokenLinkBanner.tsx",
+    },
+    {
+      // Unrelated component using a non-error token — should pass.
+      name: "Non-error token in unrelated component",
+      code: `const style = { color: "var(--afh-conf-high)" };`,
+      filename: "src/components/SourceBadge.tsx",
+    },
+  ],
+  invalid: [
+    {
+      name: "var(--afh-error) in unrelated component",
+      code: `const style = { color: "var(--afh-error)" };`,
+      filename: "src/components/SourceBadge.tsx",
+      errors: [{ messageId: "misuse" }],
+    },
+    {
+      name: "Tailwind text-afh-error in unrelated component",
+      code: 'const cls = "text-afh-error font-bold";',
+      filename: "src/components/Hero.tsx",
+      errors: [{ messageId: "misuse" }],
+    },
+    {
+      name: "Template literal embedding --afh-error-bg",
+      code: "const css = `background: var(--afh-error-bg);`;",
+      filename: "src/components/Hero.tsx",
+      errors: [{ messageId: "misuse" }],
+    },
+  ],
+});
+
+// RuleTester auto-runs assertions on import in some test runners; under Vitest
+// we trigger explicitly so the file is exercised whether invoked via
+// `node --test`, Vitest, or `npx mocha`.
+if (typeof describe === "undefined") {
+  // RuleTester.run already throws on failure when used outside Mocha-style
+  // runners, so reaching this line means all cases passed.
+  console.log("afh-error-misuse: all cases passed");
+}

--- a/eslint/__tests__/afh-error-misuse.test.js
+++ b/eslint/__tests__/afh-error-misuse.test.js
@@ -64,6 +64,35 @@ ruleTester.run("afh/afh-error-misuse", rule, {
       filename: "src/components/Hero.tsx",
       errors: [{ messageId: "misuse" }],
     },
+    {
+      // Regression: directory contains "error" but basename does not — must NOT bypass.
+      name: "Path-only 'error' must not bypass (issue 1)",
+      code: `const style = { color: "var(--afh-error)" };`,
+      filename: "src/components/error-states/SourceBadge.tsx",
+      errors: [{ messageId: "misuse" }],
+    },
+    {
+      // Regression: basename contains "invalid" as substring but the tokenised
+      // word is "Validator" — must NOT bypass (issue 2).
+      name: "Substring 'invalid' in 'InValidatorWidget' must not bypass (issue 2)",
+      code: `const style = { color: "var(--afh-error)" };`,
+      filename: "src/components/InValidatorWidget.tsx",
+      errors: [{ messageId: "misuse" }],
+    },
+    {
+      // Regression: gradient utility (`from-afh-error`) must be flagged (issue 4).
+      name: "Tailwind from-afh-error gradient is flagged",
+      code: 'const cls = "from-afh-error to-transparent";',
+      filename: "src/components/Hero.tsx",
+      errors: [{ messageId: "misuse" }],
+    },
+    {
+      // Regression: placeholder utility must be flagged (issue 4).
+      name: "Tailwind placeholder-afh-error is flagged",
+      code: 'const cls = "placeholder-afh-error";',
+      filename: "src/components/Hero.tsx",
+      errors: [{ messageId: "misuse" }],
+    },
   ],
 });
 

--- a/eslint/plugins/afh.js
+++ b/eslint/plugins/afh.js
@@ -1,0 +1,17 @@
+/**
+ * ETNI-21 — Tiny ESLint plugin wrapper that exposes Africa History
+ * design-system lint rules under the `afh/` namespace.
+ *
+ * Currently published rules:
+ *   - `afh/afh-error-misuse` — UX-DR49 rule 3
+ */
+
+"use strict";
+
+const afhErrorMisuse = require("../rules/afh-error-misuse.js");
+
+module.exports = {
+  rules: {
+    "afh-error-misuse": afhErrorMisuse,
+  },
+};

--- a/eslint/rules/afh-error-misuse.js
+++ b/eslint/rules/afh-error-misuse.js
@@ -23,19 +23,45 @@
 
 "use strict";
 
+const path = require("node:path");
+
 const ALLOWED_NAME_TOKENS = ["error", "invalid", "broken"];
 const ERROR_TOKEN_RE = /--afh-error\b/;
+// Tailwind utility prefixes that can carry an `-afh-error` colour. This list is
+// intentionally broad — every colour-bearing utility family is covered so we
+// don't silently miss e.g. `from-afh-error` in a gradient.
 const TAILWIND_ERROR_RE =
-  /\b(?:bg|text|border|ring|shadow|fill|stroke|outline)-afh-error\b/;
+  /\b(?:bg|text|border|ring|shadow|fill|stroke|outline|from|via|to|divide|placeholder|accent|caret)-afh-error\b/;
 
 /**
+ * Word-boundary match of an allowed token against the **basename only**.
+ * Splitting the basename on non-alphanumeric characters keeps the match
+ * strict: `ErrorState.tsx` → ["ErrorState", "tsx"] → ["Error", "State"]
+ * via CamelCase split, so "error" matches. `InValidatorWidget.tsx` →
+ * ["InValidatorWidget"] → ["In", "Validator", "Widget"] — none of those
+ * tokens equals "invalid", so the file does NOT bypass the rule.
+ *
+ * Tokenisation:
+ *   1. Take basename only (ignore directory path entirely).
+ *   2. Split on non-alphanumeric chars (`-`, `_`, `.`, etc.).
+ *   3. Split each chunk on CamelCase boundaries.
+ *   4. Lowercase, then test against the allow-list exactly.
+ *
  * @param {string} filename
  * @returns {boolean}
  */
 function filenameImpliesErrorContext(filename) {
   if (!filename) return false;
-  const lower = filename.toLowerCase();
-  return ALLOWED_NAME_TOKENS.some((needle) => lower.includes(needle));
+  const base = path.basename(filename);
+  // Strip extensions (handles .stories.tsx, .test.ts, etc. defensively).
+  const stem = base.replace(/\..*$/, "");
+  // Split on non-alphanumeric, then on CamelCase boundaries.
+  const tokens = stem
+    .split(/[^A-Za-z0-9]+/)
+    .flatMap((chunk) => chunk.split(/(?=[A-Z])/))
+    .map((tok) => tok.toLowerCase())
+    .filter(Boolean);
+  return tokens.some((tok) => ALLOWED_NAME_TOKENS.includes(tok));
 }
 
 /** @type {import("eslint").Rule.RuleModule} */

--- a/eslint/rules/afh-error-misuse.js
+++ b/eslint/rules/afh-error-misuse.js
@@ -1,0 +1,94 @@
+/**
+ * ETNI-21 / UX-DR49 rule 3 — `--afh-error` misuse detector.
+ *
+ * The `--afh-error` token (and its `--afh-error-bg` / `--afh-error-border`
+ * companions) is reserved for components dedicated to error / invalid /
+ * broken-state UI. Sprinkling error red elsewhere creates ambiguous
+ * affordances and undermines the warning vocabulary of the design system.
+ *
+ * Heuristic: a component file may reference `--afh-error*` only when its
+ * filename or default export identifier contains "Error", "Invalid", or
+ * "Broken" (case-insensitive). Otherwise the reference is flagged.
+ *
+ * Scope: applied to source files under `src/components/` and `src/app/`
+ * (configured in the top-level `eslint.config.mjs`). Storybook files
+ * (`*.stories.*`, `*.mdx`) and test files are exempt.
+ *
+ * The rule walks every string literal and template literal in the AST,
+ * which is sufficient for JSX `style={{ color: "var(--afh-error)" }}`,
+ * inline strings, and `cn("text-afh-error", ...)` style usage. Token
+ * references inside `.css` files are intentionally out of scope —
+ * CSS files are not parsed by ESLint here.
+ */
+
+"use strict";
+
+const ALLOWED_NAME_TOKENS = ["error", "invalid", "broken"];
+const ERROR_TOKEN_RE = /--afh-error\b/;
+const TAILWIND_ERROR_RE =
+  /\b(?:bg|text|border|ring|shadow|fill|stroke|outline)-afh-error\b/;
+
+/**
+ * @param {string} filename
+ * @returns {boolean}
+ */
+function filenameImpliesErrorContext(filename) {
+  if (!filename) return false;
+  const lower = filename.toLowerCase();
+  return ALLOWED_NAME_TOKENS.some((needle) => lower.includes(needle));
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `--afh-error` outside components whose filename contains Error/Invalid/Broken (UX-DR49 rule 3).",
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      misuse:
+        "`--afh-error` is reserved for Error / Invalid / Broken components. " +
+        "Rename the component (e.g. *ErrorState.tsx) or pick a non-error token " +
+        "(--afh-flag-open, --afh-conf-low, --afh-classification-disputed).",
+    },
+  },
+
+  create(context) {
+    const filename = context.filename || context.getFilename?.() || "";
+    if (filenameImpliesErrorContext(filename)) {
+      return {};
+    }
+
+    /**
+     * @param {{ value?: unknown }} node
+     * @returns {string | null}
+     */
+    function literalText(node) {
+      if (typeof node.value === "string") return node.value;
+      return null;
+    }
+
+    function check(node, text) {
+      if (!text) return;
+      if (ERROR_TOKEN_RE.test(text) || TAILWIND_ERROR_RE.test(text)) {
+        context.report({ node, messageId: "misuse" });
+      }
+    }
+
+    return {
+      Literal(node) {
+        check(node, literalText(node));
+      },
+      TemplateElement(node) {
+        const raw = node.value && (node.value.cooked ?? node.value.raw);
+        check(node, raw || "");
+      },
+      JSXText(node) {
+        check(node, node.value || "");
+      },
+    };
+  },
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,13 @@
-@import './styles/country-tokens.css';
+/* Africa History (--afh-*) token foundation — ETNI-21.
+   Imported BEFORE country-tokens.css so `--country-*` aliases
+   can layer on top during the one-release deprecation window. */
+@import "./styles/tokens/color.css";
+@import "./styles/tokens/type.css";
+@import "./styles/tokens/space.css";
+@import "./styles/tokens/elevation.css";
+@import "./styles/tokens/motion.css";
+@import "./styles/tokens/radius.css";
+@import "./styles/country-tokens.css";
 
 @tailwind base;
 @tailwind components;
@@ -45,7 +54,7 @@ All colors MUST be HSL.
     --ring: 18 70% 52%;
 
     --radius: 0.75rem;
-    
+
     /* Custom African-inspired tokens */
     --terracotta: 18 70% 52%;
     --terracotta-light: 18 65% 65%;
@@ -54,15 +63,15 @@ All colors MUST be HSL.
     --earth-light: 25 25% 45%;
     --ochre: 32 75% 55%;
     --sand: 35 40% 85%;
-    
+
     /* Gradients */
     --gradient-warm: linear-gradient(135deg, hsl(18 70% 52%), hsl(42 88% 58%));
     --gradient-earth: linear-gradient(180deg, hsl(35 35% 97%), hsl(35 40% 92%));
-    
+
     /* Shadows */
     --shadow-warm: 0 10px 40px -10px hsl(18 70% 52% / 0.2);
     --shadow-soft: 0 4px 20px -5px hsl(25 25% 15% / 0.08);
-    
+
     /* Transitions */
     --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 
@@ -111,7 +120,7 @@ All colors MUST be HSL.
     --border: 25 15% 24%;
     --input: 25 15% 24%;
     --ring: 18 70% 55%;
-    
+
     --terracotta: 18 70% 55%;
     --terracotta-light: 18 65% 68%;
     --gold: 42 85% 60%;
@@ -119,7 +128,7 @@ All colors MUST be HSL.
     --earth-light: 35 20% 65%;
     --ochre: 32 75% 58%;
     --sand: 35 15% 28%;
-    
+
     --shadow-warm: 0 10px 40px -10px hsl(18 70% 55% / 0.3);
     --shadow-soft: 0 4px 20px -5px hsl(0 0% 0% / 0.3);
     --sidebar-background: 240 5.9% 10%;
@@ -142,8 +151,13 @@ All colors MUST be HSL.
     @apply bg-background text-foreground font-sans antialiased;
     font-family: var(--font-inter), sans-serif;
   }
-  
-  h1, h2, h3, h4, h5, h6 {
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     @apply font-display;
     font-family: var(--font-playfair), serif;
   }
@@ -153,19 +167,19 @@ All colors MUST be HSL.
   .gradient-warm {
     background: var(--gradient-warm);
   }
-  
+
   .gradient-earth {
     background: var(--gradient-earth);
   }
-  
+
   .shadow-warm {
     box-shadow: var(--shadow-warm);
   }
-  
+
   .shadow-soft {
     box-shadow: var(--shadow-soft);
   }
-  
+
   .transition-smooth {
     transition: var(--transition-smooth);
   }

--- a/src/stories/design-system/Color.mdx
+++ b/src/stories/design-system/Color.mdx
@@ -1,0 +1,119 @@
+import { Meta, ColorPalette, ColorItem } from "@storybook/blocks";
+
+<Meta title="Design System/Color" />
+
+# Color — `--afh-color-*` / `--afh-*`
+
+Two-layer system defined in `src/styles/tokens/color.css`.
+
+- **L1 — raw palette** (`--afh-color-*`): immutable hex values.
+- **L2 — semantic aliases** (`--afh-bg`, `--afh-conf-high`, `--afh-source-primary`, …): consumed by components.
+
+> `--country-*` tokens remain available for one release as deprecation aliases.
+
+## Surface
+
+<ColorPalette>
+  <ColorItem
+    title="Background"
+    subtitle="--afh-bg"
+    colors={{ "#FBF7F2": "#FBF7F2" }}
+  />
+  <ColorItem
+    title="Background warm"
+    subtitle="--afh-bg-warm"
+    colors={{ "#F5EDE0": "#F5EDE0" }}
+  />
+  <ColorItem
+    title="Surface (card)"
+    subtitle="--afh-surface"
+    colors={{ "#FFFFFF": "#FFFFFF" }}
+  />
+  <ColorItem
+    title="Border"
+    subtitle="--afh-border"
+    colors={{ "#E8DFD3": "#E8DFD3" }}
+  />
+</ColorPalette>
+
+## Text
+
+<ColorPalette>
+  <ColorItem title="Text" subtitle="--afh-text" colors={{ "#2C2018": "#2C2018" }} />
+  <ColorItem title="Text soft" subtitle="--afh-text-soft" colors={{ "#7A6B5D": "#7A6B5D" }} />
+  <ColorItem title="Text muted" subtitle="--afh-text-muted" colors={{ "#9B8B7D": "#9B8B7D" }} />
+</ColorPalette>
+
+## Accents
+
+<ColorPalette>
+  <ColorItem title="Earth" subtitle="--afh-earth" colors={{ "#8B6B47": "#8B6B47" }} />
+  <ColorItem title="Terracotta" subtitle="--afh-terracotta" colors={{ "#C2532A": "#C2532A" }} />
+  <ColorItem title="Gold" subtitle="--afh-gold" colors={{ "#B8860B": "#B8860B" }} />
+</ColorPalette>
+
+## Confidence tier
+
+Used by source / data-lineage badges (see ETNI-26).
+
+<ColorPalette>
+  <ColorItem
+    title="High"
+    subtitle="--afh-conf-high · 95–100 % corroborated"
+    colors={{ fg: "#2B6B42", bg: "#E8F5ED" }}
+  />
+  <ColorItem
+    title="Mid"
+    subtitle="--afh-conf-mid · 70–94 % mixed"
+    colors={{ fg: "#D4A843", bg: "#FDF5E1" }}
+  />
+  <ColorItem
+    title="Low"
+    subtitle="--afh-conf-low · < 70 % / single source"
+    colors={{ fg: "#B87D5B", bg: "#F3EBE0" }}
+  />
+</ColorPalette>
+
+## Classification state
+
+<ColorPalette>
+  <ColorItem
+    title="Stable"
+    subtitle="--afh-classification-stable"
+    colors={{ fg: "#2B6B42", bg: "#E8F5ED" }}
+  />
+  <ColorItem
+    title="Contested"
+    subtitle="--afh-classification-contested"
+    colors={{ fg: "#D4A843", bg: "#FDF5E1" }}
+  />
+  <ColorItem
+    title="Disputed"
+    subtitle="--afh-classification-disputed"
+    colors={{ fg: "#9B3030", bg: "#FCE8E8" }}
+  />
+</ColorPalette>
+
+## Source tier
+
+<ColorPalette>
+  <ColorItem title="Primary" subtitle="--afh-source-primary" colors={{ fg: "#2B6B42", bg: "#E8F5ED" }} />
+  <ColorItem title="Secondary" subtitle="--afh-source-secondary" colors={{ fg: "#5B8DB8", bg: "#E6F0F7" }} />
+  <ColorItem title="AI-flagged" subtitle="--afh-source-ai-flagged" colors={{ fg: "#B87D5B", bg: "#F3EBE0" }} />
+</ColorPalette>
+
+## Flag state
+
+<ColorPalette>
+  <ColorItem title="Open" subtitle="--afh-flag-open" colors={{ fg: "#C2532A", bg: "#FCEEE8" }} />
+  <ColorItem title="Resolved" subtitle="--afh-flag-resolved" colors={{ fg: "#2B6B42", bg: "#E8F5ED" }} />
+</ColorPalette>
+
+## Error (reserved)
+
+Use only inside components whose filename contains `Error`, `Invalid`, or `Broken`.
+Misuse is enforced by the `afh/afh-error-misuse` ESLint rule (UX-DR49 rule 3).
+
+<ColorPalette>
+  <ColorItem title="Error" subtitle="--afh-error" colors={{ fg: "#9B3030", bg: "#FCE8E8" }} />
+</ColorPalette>

--- a/src/stories/design-system/Elevation.mdx
+++ b/src/stories/design-system/Elevation.mdx
@@ -1,0 +1,55 @@
+import { Meta } from "@storybook/blocks";
+
+<Meta title="Design System/Elevation" />
+
+# Elevation — `--afh-elev-*`
+
+Six-step scale, warm earth-toned shadows. Defined in
+`src/styles/tokens/elevation.css`.
+
+<div
+  style={{
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+    gap: "2rem",
+    margin: "2rem 0",
+    background: "var(--afh-bg)",
+    padding: "2rem",
+    borderRadius: "12px",
+  }}
+>
+  {[
+    ["--afh-elev-0",    "var(--afh-elev-0)",    "None"],
+    ["--afh-elev-1",    "var(--afh-elev-1)",    "Subtle hover"],
+    ["--afh-elev-2",    "var(--afh-elev-2)",    "Resting card"],
+    ["--afh-elev-3",    "var(--afh-elev-3)",    "Raised card"],
+    ["--afh-elev-4",    "var(--afh-elev-4)",    "Popover / sticky"],
+    ["--afh-elev-5",    "var(--afh-elev-5)",    "Dialog / modal"],
+    ["--afh-elev-warm", "var(--afh-elev-warm)", "Hero / featured"],
+  ].map(([token, shadow, role]) => (
+    <div key={token} style={{ textAlign: "center" }}>
+      <div
+        style={{
+          height: "80px",
+          background: "var(--afh-surface)",
+          borderRadius: "12px",
+          boxShadow: shadow,
+          marginBottom: "0.75rem",
+        }}
+      />
+      <code style={{ fontSize: "12px", display: "block" }}>{token}</code>
+      <span style={{ fontSize: "11px", color: "var(--afh-text-soft)" }}>{role}</span>
+    </div>
+  ))}
+</div>
+
+## Focus ring
+
+`--afh-ring-focus` — a two-layer outline that survives over any background.
+
+```css
+:focus-visible {
+  box-shadow: var(--afh-ring-focus);
+  outline: none;
+}
+```

--- a/src/stories/design-system/Motion.mdx
+++ b/src/stories/design-system/Motion.mdx
@@ -1,0 +1,88 @@
+import { Meta } from "@storybook/blocks";
+
+<Meta title="Design System/Motion" />
+
+# Motion — `--afh-duration-*` / `--afh-ease-*`
+
+Defined in `src/styles/tokens/motion.css`.
+
+## Durations
+
+| Token | Value | Suggested use |
+| --- | --- | --- |
+| `--afh-duration-instant` | 0.01 ms | Reduced-motion fallback |
+| `--afh-duration-fast` | 120 ms | Micro-feedback (tap, hover) |
+| `--afh-duration-base` | 200 ms | Default UI transitions |
+| `--afh-duration-slow` | 320 ms | State changes (open/close) |
+| `--afh-duration-fade` | 400 ms | Cross-fades, content swaps |
+| `--afh-duration-pageload` | 600 ms | Page-level fades |
+
+## Easings
+
+| Token | Curve |
+| --- | --- |
+| `--afh-ease-linear` | linear |
+| `--afh-ease-in` | `cubic-bezier(0.4, 0, 1, 1)` |
+| `--afh-ease-out` | `cubic-bezier(0, 0, 0.2, 1)` |
+| `--afh-ease-in-out` | `cubic-bezier(0.4, 0, 0.2, 1)` |
+| `--afh-ease-default` | `ease` |
+
+## Composed transitions
+
+| Token | What it animates |
+| --- | --- |
+| `--afh-transition-color` | `color`, `background-color`, `border-color` |
+| `--afh-transition-opacity` | `opacity` |
+| `--afh-transition-transform` | `transform` |
+| `--afh-transition-all` | `all` (debug / quick prototypes) |
+
+## Reduced-motion contract
+
+When `prefers-reduced-motion: reduce` is set, the motion tokens **collapse to
+0.01 ms** and every composed transition is rewritten to `opacity 0.01ms linear`.
+No transforms run. This is enforced at the token layer — callers do not have to
+write extra media queries.
+
+Test it in DevTools → Rendering → "Emulate CSS prefers-reduced-motion".
+
+```css
+/* Caller code stays simple */
+.fade-in {
+  transition: var(--afh-transition-opacity);
+}
+/* Both motion-on and motion-reduce users get a sane experience. */
+```
+
+## Live demo
+
+<div
+  style={{
+    display: "flex",
+    gap: "1rem",
+    alignItems: "center",
+    padding: "1.5rem",
+    background: "var(--afh-bg-warm)",
+    borderRadius: "12px",
+    margin: "1.5rem 0",
+  }}
+>
+  <button
+    type="button"
+    style={{
+      padding: "8px 16px",
+      background: "var(--afh-terracotta)",
+      color: "white",
+      border: "none",
+      borderRadius: "6px",
+      cursor: "pointer",
+      transition: "var(--afh-transition-all)",
+    }}
+    onMouseEnter={(e) => (e.currentTarget.style.transform = "translateY(-2px)")}
+    onMouseLeave={(e) => (e.currentTarget.style.transform = "translateY(0)")}
+  >
+    Hover me
+  </button>
+  <span style={{ fontSize: "12px", color: "var(--afh-text-soft)" }}>
+    Uses `--afh-transition-all` · respects reduced-motion.
+  </span>
+</div>

--- a/src/stories/design-system/Radii.mdx
+++ b/src/stories/design-system/Radii.mdx
@@ -1,0 +1,42 @@
+import { Meta } from "@storybook/blocks";
+
+<Meta title="Design System/Radii" />
+
+# Radii — `--afh-radius-*`
+
+Defined in `src/styles/tokens/radius.css`. Soft, organic curves echoing the
+earth / terracotta aesthetic.
+
+<div
+  style={{
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+    gap: "1.5rem",
+    margin: "1.5rem 0",
+  }}
+>
+  {[
+    ["--afh-radius-0",    "0"],
+    ["--afh-radius-sm",   "4px"],
+    ["--afh-radius-md",   "6px"],
+    ["--afh-radius-base", "12px"],
+    ["--afh-radius-lg",   "14px"],
+    ["--afh-radius-xl",   "16px"],
+    ["--afh-radius-2xl",  "20px"],
+    ["--afh-radius-3xl",  "28px"],
+    ["--afh-radius-full", "9999px"],
+  ].map(([token, value]) => (
+    <div key={token} style={{ textAlign: "center" }}>
+      <div
+        style={{
+          height: "80px",
+          background: "var(--afh-terracotta)",
+          borderRadius: value,
+          marginBottom: "0.5rem",
+        }}
+      />
+      <code style={{ fontSize: "12px", display: "block" }}>{token}</code>
+      <span style={{ fontSize: "11px", color: "var(--afh-text-soft)" }}>{value}</span>
+    </div>
+  ))}
+</div>

--- a/src/stories/design-system/Spacing.mdx
+++ b/src/stories/design-system/Spacing.mdx
@@ -1,0 +1,52 @@
+import { Meta } from "@storybook/blocks";
+
+<Meta title="Design System/Spacing" />
+
+# Spacing — `--afh-space-*`
+
+4 px base, T-shirt scale plus numeric multipliers. Defined in
+`src/styles/tokens/space.css`.
+
+<div style={{ display: "flex", flexDirection: "column", gap: "0.5rem", margin: "1.5rem 0" }}>
+  {[
+    ["--afh-space-xs",   "4px"],
+    ["--afh-space-sm",   "6px"],
+    ["--afh-space-md",   "8px"],
+    ["--afh-space-base", "10px"],
+    ["--afh-space-lg",   "12px"],
+    ["--afh-space-xl",   "14px"],
+    ["--afh-space-2xl",  "16px"],
+    ["--afh-space-3xl",  "18px"],
+    ["--afh-space-4xl",  "20px"],
+    ["--afh-space-5xl",  "24px"],
+    ["--afh-space-6xl",  "32px"],
+    ["--afh-space-7xl",  "40px"],
+    ["--afh-space-8xl",  "48px"],
+    ["--afh-space-9xl",  "64px"],
+    ["--afh-space-10xl", "96px"],
+  ].map(([token, value]) => (
+    <div key={token} style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+      <code style={{ minWidth: "180px" }}>{token}</code>
+      <div
+        style={{
+          width: value,
+          height: "16px",
+          background: "var(--afh-terracotta)",
+          borderRadius: "2px",
+        }}
+      />
+      <span style={{ fontSize: "12px", color: "var(--afh-text-soft)" }}>{value}</span>
+    </div>
+  ))}
+</div>
+
+## Layout-level aliases
+
+Mobile-first containers scale up at tablet (≥ 768 px) and desktop (≥ 1200 px).
+
+| Token | Mobile | Tablet | Desktop |
+| --- | --- | --- | --- |
+| `--afh-page-padding` | 12 px | 24 px | 32 px |
+| `--afh-card-padding` | 18 px | 24 px | 32 px |
+| `--afh-section-gap` | 24 px | 32 px | 48 px |
+| `--afh-container-max` | 430 px | 720 px | 800 px |

--- a/src/stories/design-system/Type.mdx
+++ b/src/stories/design-system/Type.mdx
@@ -1,0 +1,96 @@
+import { Meta } from "@storybook/blocks";
+
+<Meta title="Design System/Type" />
+
+# Typography — `--afh-text-*`
+
+Defined in `src/styles/tokens/type.css`. Two families layered on top of the
+`next/font/google` imports already wired in `src/app/layout.tsx`:
+
+| Family | Variable | Usage |
+| --- | --- | --- |
+| **Fraunces** | `--font-fraunces` / `--afh-font-display` | Hero, H1–H3 — editorial display |
+| **Nunito Sans** | `--font-nunito-sans` / `--afh-font-body` | Body, captions, UI |
+
+## 9-role scale
+
+Mobile-first, with two scale-up breakpoints (768 px tablet, 1200 px desktop).
+Sizes below are the **mobile** values.
+
+<div style={{ display: "grid", gap: "1.5rem", margin: "1.5rem 0" }}>
+  <div>
+    <div style={{ fontFamily: "var(--afh-font-display)", fontSize: "var(--afh-text-hero)", fontWeight: 700, lineHeight: 1.1 }}>
+      Hero · 34 px
+    </div>
+    <code>--afh-text-hero</code>
+  </div>
+  <div>
+    <div style={{ fontFamily: "var(--afh-font-display)", fontSize: "var(--afh-text-h1)", fontWeight: 700, lineHeight: 1.2 }}>
+      H1 · 24 px
+    </div>
+    <code>--afh-text-h1</code>
+  </div>
+  <div>
+    <div style={{ fontFamily: "var(--afh-font-display)", fontSize: "var(--afh-text-h2)", fontWeight: 700, lineHeight: 1.25 }}>
+      H2 · 18 px
+    </div>
+    <code>--afh-text-h2</code>
+  </div>
+  <div>
+    <div style={{ fontFamily: "var(--afh-font-display)", fontSize: "var(--afh-text-h3)", fontWeight: 600, lineHeight: 1.3 }}>
+      H3 · 16 px
+    </div>
+    <code>--afh-text-h3</code>
+  </div>
+  <div>
+    <div style={{ fontFamily: "var(--afh-font-body)", fontSize: "var(--afh-text-body)", lineHeight: 1.6 }}>
+      Body · 14 px — Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+    <code>--afh-text-body</code>
+  </div>
+  <div>
+    <div style={{ fontFamily: "var(--afh-font-body)", fontSize: "var(--afh-text-small)", lineHeight: 1.5 }}>
+      Small · 12 px
+    </div>
+    <code>--afh-text-small</code>
+  </div>
+  <div>
+    <div style={{ fontFamily: "var(--afh-font-body)", fontSize: "var(--afh-text-caption)", lineHeight: 1.45 }}>
+      Caption · 11 px
+    </div>
+    <code>--afh-text-caption</code>
+  </div>
+  <div>
+    <div style={{ fontFamily: "var(--afh-font-body)", fontSize: "var(--afh-text-micro)", lineHeight: 1.4, textTransform: "uppercase", letterSpacing: "0.1em" }}>
+      Micro · 10 px
+    </div>
+    <code>--afh-text-micro</code>
+  </div>
+  <div>
+    <div style={{ fontFamily: "var(--afh-font-body)", fontSize: "var(--afh-text-nano)", lineHeight: 1.4, textTransform: "uppercase", letterSpacing: "0.12em" }}>
+      Nano · 9 px
+    </div>
+    <code>--afh-text-nano</code>
+  </div>
+</div>
+
+## Density profiles (UX-DR48)
+
+`line-height` aliases that callers attach to body containers depending on context.
+
+| Token | Value | Use case |
+| --- | --- | --- |
+| `--afh-density-reading` | `1.65` | Public fiches, long-form articles |
+| `--afh-density-moderation` | `1.35` | Admin tables, contribution diffs |
+| `--afh-density-developer` | `1.35` | Debug surfaces, API explorer |
+
+## Weights
+
+| Variable | Value |
+| --- | --- |
+| `--afh-weight-regular` | 400 |
+| `--afh-weight-medium` | 500 |
+| `--afh-weight-semibold` | 600 |
+| `--afh-weight-bold` | 700 |
+| `--afh-weight-heavy` | 800 |
+| `--afh-weight-black` | 900 |

--- a/src/styles/country-tokens.css
+++ b/src/styles/country-tokens.css
@@ -2,30 +2,36 @@
    ETHNAFRICA — Country Page Design Tokens
    Variante C "Carte vivante"
    v1.0
+
+   ETNI-21 update: principal colour/typography tokens are now
+   aliased to their `--afh-*` equivalents (defined in
+   `src/styles/tokens/color.css` and `src/styles/tokens/type.css`).
+   Layout, animation, spacing and component-class tokens below
+   remain page-specific.
    ============================================================ */
 
 :root {
-  /* === COULEURS — Fond === */
-  --country-bg: #FBF7F2;
-  --country-bg-warm: #F5EDE0;
-  --country-card: #FFFFFF;
-  --country-border: #E8DFD3;
+  /* === COULEURS — Fond (aliased to --afh-color-* / --afh-*) === */
+  --country-bg: var(--afh-color-bg);
+  --country-bg-warm: var(--afh-color-bg-warm);
+  --country-card: var(--afh-color-card);
+  --country-border: var(--afh-color-border);
 
   /* === COULEURS — Texte === */
-  --country-text: #2C2018;
-  --country-text-soft: #7A6B5D;
+  --country-text: var(--afh-color-text);
+  --country-text-soft: var(--afh-color-text-soft);
 
-  /* === COULEURS — Sémantiques === */
-  --country-gold: #B8860B;
-  --country-gold-bg: #FDF5E1;
-  --country-green: #2B6B42;
-  --country-green-bg: #E8F5ED;
-  --country-terracotta: #C2532A;
-  --country-terracotta-bg: #FCEEE8;
-  --country-earth: #8B6B47;
-  --country-earth-bg: #F3EBE0;
-  --country-colonial: #9B3030;
-  --country-colonial-bg: #FCE8E8;
+  /* === COULEURS — Sémantiques (aliased to --afh-color-*) === */
+  --country-gold: var(--afh-color-gold);
+  --country-gold-bg: var(--afh-color-gold-bg);
+  --country-green: var(--afh-color-green);
+  --country-green-bg: var(--afh-color-green-bg);
+  --country-terracotta: var(--afh-color-terracotta);
+  --country-terracotta-bg: var(--afh-color-terracotta-bg);
+  --country-earth: var(--afh-color-earth);
+  --country-earth-bg: var(--afh-color-earth-bg);
+  --country-colonial: var(--afh-color-colonial);
+  --country-colonial-bg: var(--afh-color-colonial-bg);
 
   /* === COULEURS — Barre démographique === */
   --country-demo-1: #D4A843;
@@ -46,9 +52,9 @@
   --country-hero-end: #142E1E;
   --country-hero-highlight: #F5C842;
 
-  /* === TYPOGRAPHIE === */
-  --country-font-display: var(--font-fraunces), 'Fraunces', Georgia, serif;
-  --country-font-body: var(--font-nunito-sans), 'Nunito Sans', system-ui, sans-serif;
+  /* === TYPOGRAPHIE (aliased to --afh-font-*) === */
+  --country-font-display: var(--afh-font-display);
+  --country-font-body: var(--afh-font-body);
 
   /* Échelle typo (mobile-first) */
   --country-text-hero: 34px;

--- a/src/styles/tokens/color.css
+++ b/src/styles/tokens/color.css
@@ -1,0 +1,104 @@
+/* ============================================================
+   Africa History — Color Tokens
+   ETNI-21 · Epic 1 (Source Transparency Fabric) · UX-DR1
+   ------------------------------------------------------------
+   Two-layer system:
+     L1 — raw palette (--afh-color-*)
+     L2 — semantic aliases (confidence / classification / source /
+          flag-state / surface / accents)
+
+   Existing --country-* tokens (src/styles/country-tokens.css) are
+   preserved unchanged for one release; selected --country-* are
+   re-aliased below to --afh-* values to keep callers in sync.
+   ============================================================ */
+
+:root {
+  /* ─── L1 · Raw palette ─────────────────────────────────────── */
+  --afh-color-bg: #fbf7f2;
+  --afh-color-bg-warm: #f5ede0;
+  --afh-color-card: #ffffff;
+  --afh-color-border: #e8dfd3;
+
+  --afh-color-text: #2c2018;
+  --afh-color-text-soft: #7a6b5d;
+  --afh-color-text-muted: #9b8b7d;
+
+  --afh-color-gold: #b8860b;
+  --afh-color-gold-bg: #fdf5e1;
+  --afh-color-green: #2b6b42;
+  --afh-color-green-bg: #e8f5ed;
+  --afh-color-terracotta: #c2532a;
+  --afh-color-terracotta-bg: #fceee8;
+  --afh-color-earth: #8b6b47;
+  --afh-color-earth-bg: #f3ebe0;
+  --afh-color-colonial: #9b3030;
+  --afh-color-colonial-bg: #fce8e8;
+
+  --afh-color-amber: #d4a843;
+  --afh-color-azure: #5b8db8;
+  --afh-color-sage: #6baf8d;
+  --afh-color-clay: #b87d5b;
+  --afh-color-slate: #5b6b7b;
+
+  /* Error palette — reserved for Error / Invalid / Broken UI only.
+     Enforced by eslint/rules/afh-error-misuse.js (UX-DR49 rule 3). */
+  --afh-color-error: #9b3030;
+  --afh-color-error-bg: #fce8e8;
+  --afh-color-error-border: #e5b8b8;
+
+  /* ─── L2 · Semantic aliases ────────────────────────────────── */
+
+  /* Surface */
+  --afh-bg: var(--afh-color-bg);
+  --afh-bg-warm: var(--afh-color-bg-warm);
+  --afh-surface: var(--afh-color-card);
+  --afh-border: var(--afh-color-border);
+
+  /* Text */
+  --afh-text: var(--afh-color-text);
+  --afh-text-soft: var(--afh-color-text-soft);
+  --afh-text-muted: var(--afh-color-text-muted);
+
+  /* Accents (kept from V1 country palette) */
+  --afh-earth: var(--afh-color-earth);
+  --afh-terracotta: var(--afh-color-terracotta);
+  --afh-gold: var(--afh-color-gold);
+
+  /* Confidence tier — applied to data lineage badges, sources, etc.
+     high  → 95–100 % corroborated by primary sources
+     mid   → 70–94 %  mixed primary + secondary
+     low   → < 70 %   single source or AI-flagged */
+  --afh-conf-high: var(--afh-color-green);
+  --afh-conf-high-bg: var(--afh-color-green-bg);
+  --afh-conf-mid: var(--afh-color-amber);
+  --afh-conf-mid-bg: var(--afh-color-gold-bg);
+  --afh-conf-low: var(--afh-color-clay);
+  --afh-conf-low-bg: var(--afh-color-earth-bg);
+
+  /* Classification state — fiche-level editorial status */
+  --afh-classification-stable: var(--afh-color-green);
+  --afh-classification-stable-bg: var(--afh-color-green-bg);
+  --afh-classification-contested: var(--afh-color-amber);
+  --afh-classification-contested-bg: var(--afh-color-gold-bg);
+  --afh-classification-disputed: var(--afh-color-colonial);
+  --afh-classification-disputed-bg: var(--afh-color-colonial-bg);
+
+  /* Source tier — authority signal for citations */
+  --afh-source-primary: var(--afh-color-green);
+  --afh-source-primary-bg: var(--afh-color-green-bg);
+  --afh-source-secondary: var(--afh-color-azure);
+  --afh-source-secondary-bg: #e6f0f7;
+  --afh-source-ai-flagged: var(--afh-color-clay);
+  --afh-source-ai-flagged-bg: var(--afh-color-earth-bg);
+
+  /* Flag state — moderation / report-error / open-issue surfaces */
+  --afh-flag-open: var(--afh-color-terracotta);
+  --afh-flag-open-bg: var(--afh-color-terracotta-bg);
+  --afh-flag-resolved: var(--afh-color-green);
+  --afh-flag-resolved-bg: var(--afh-color-green-bg);
+
+  /* Error — reserved (see L1 above) */
+  --afh-error: var(--afh-color-error);
+  --afh-error-bg: var(--afh-color-error-bg);
+  --afh-error-border: var(--afh-color-error-border);
+}

--- a/src/styles/tokens/elevation.css
+++ b/src/styles/tokens/elevation.css
@@ -1,0 +1,37 @@
+/* ============================================================
+   Africa History — Elevation Tokens
+   ETNI-21 · UX-DR5
+   ------------------------------------------------------------
+   Six-step elevation scale, warm earth-toned shadows. Tracks
+   shadcn surfaces (cards, dialogs, popovers) without breaking
+   them — components can opt-in via `box-shadow: var(--afh-elev-N)`.
+   ============================================================ */
+
+:root {
+  --afh-elev-0: none;
+
+  --afh-elev-1:
+    0 1px 2px -1px hsl(25 25% 15% / 0.05), 0 1px 1px 0 hsl(25 25% 15% / 0.04);
+
+  --afh-elev-2:
+    0 2px 4px -2px hsl(25 25% 15% / 0.06), 0 4px 8px -2px hsl(25 25% 15% / 0.06);
+
+  --afh-elev-3:
+    0 4px 8px -2px hsl(25 25% 15% / 0.08),
+    0 8px 16px -4px hsl(25 25% 15% / 0.08);
+
+  --afh-elev-4:
+    0 8px 16px -4px hsl(25 25% 15% / 0.1),
+    0 16px 32px -8px hsl(25 25% 15% / 0.1);
+
+  --afh-elev-5:
+    0 16px 32px -8px hsl(25 25% 15% / 0.12),
+    0 32px 64px -16px hsl(25 25% 15% / 0.12);
+
+  /* Warm elevation — for hero / featured cards */
+  --afh-elev-warm: 0 10px 40px -10px hsl(18 70% 52% / 0.2);
+
+  /* Focus ring — accessibility */
+  --afh-ring-focus:
+    0 0 0 2px var(--afh-bg), 0 0 0 4px var(--afh-color-terracotta);
+}

--- a/src/styles/tokens/motion.css
+++ b/src/styles/tokens/motion.css
@@ -1,0 +1,59 @@
+/* ============================================================
+   Africa History — Motion Tokens
+   ETNI-21 · UX-DR6, UX-DR49 rule 4
+   ------------------------------------------------------------
+   Durations, easings, and named transitions.
+
+   Accessibility: when `prefers-reduced-motion: reduce` is set,
+   every duration collapses to 0.01 ms and transforms are
+   neutralised — only opacity transitions remain. This is the
+   contract callers can rely on.
+   ============================================================ */
+
+:root {
+  /* Durations */
+  --afh-duration-instant: 0.01ms;
+  --afh-duration-fast: 120ms;
+  --afh-duration-base: 200ms;
+  --afh-duration-slow: 320ms;
+  --afh-duration-fade: 400ms;
+  --afh-duration-pageload: 600ms;
+
+  /* Easings */
+  --afh-ease-linear: linear;
+  --afh-ease-in: cubic-bezier(0.4, 0, 1, 1);
+  --afh-ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --afh-ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --afh-ease-default: ease;
+
+  /* Composed transitions */
+  --afh-transition-color:
+    color var(--afh-duration-base) var(--afh-ease-in-out),
+    background-color var(--afh-duration-base) var(--afh-ease-in-out),
+    border-color var(--afh-duration-base) var(--afh-ease-in-out);
+  --afh-transition-opacity: opacity var(--afh-duration-base)
+    var(--afh-ease-in-out);
+  --afh-transition-transform: transform var(--afh-duration-base)
+    var(--afh-ease-in-out);
+  --afh-transition-all: all var(--afh-duration-base) var(--afh-ease-in-out);
+}
+
+/* ─────────────────────────────────────────────────────────────
+   prefers-reduced-motion · UX-DR49 rule 4
+   All durations → 0.01 ms · transforms neutralised · opacity only
+   ───────────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --afh-duration-instant: 0.01ms;
+    --afh-duration-fast: 0.01ms;
+    --afh-duration-base: 0.01ms;
+    --afh-duration-slow: 0.01ms;
+    --afh-duration-fade: 0.01ms;
+    --afh-duration-pageload: 0.01ms;
+
+    --afh-transition-color: opacity 0.01ms linear;
+    --afh-transition-opacity: opacity 0.01ms linear;
+    --afh-transition-transform: opacity 0.01ms linear;
+    --afh-transition-all: opacity 0.01ms linear;
+  }
+}

--- a/src/styles/tokens/radius.css
+++ b/src/styles/tokens/radius.css
@@ -1,0 +1,18 @@
+/* ============================================================
+   Africa History — Radius Tokens
+   ETNI-21
+   ------------------------------------------------------------
+   Soft, organic curves echoing earth/terracotta aesthetic.
+   ============================================================ */
+
+:root {
+  --afh-radius-0: 0;
+  --afh-radius-sm: 4px;
+  --afh-radius-md: 6px;
+  --afh-radius-base: 12px;
+  --afh-radius-lg: 14px;
+  --afh-radius-xl: 16px;
+  --afh-radius-2xl: 20px;
+  --afh-radius-3xl: 28px;
+  --afh-radius-full: 9999px;
+}

--- a/src/styles/tokens/space.css
+++ b/src/styles/tokens/space.css
@@ -1,0 +1,52 @@
+/* ============================================================
+   Africa History — Spacing Tokens
+   ETNI-21 · UX-DR4
+   ------------------------------------------------------------
+   4 px base, T-shirt scale plus numeric aliases. Used for
+   padding, margin, gap, and absolute offsets across all L3
+   components.
+   ============================================================ */
+
+:root {
+  --afh-space-0: 0;
+  --afh-space-px: 1px;
+  --afh-space-xs: 4px; /* 1 ×  */
+  --afh-space-sm: 6px;
+  --afh-space-md: 8px; /* 2 ×  */
+  --afh-space-base: 10px;
+  --afh-space-lg: 12px; /* 3 ×  */
+  --afh-space-xl: 14px;
+  --afh-space-2xl: 16px; /* 4 ×  */
+  --afh-space-3xl: 18px;
+  --afh-space-4xl: 20px; /* 5 ×  */
+  --afh-space-5xl: 24px; /* 6 ×  */
+  --afh-space-6xl: 32px; /* 8 ×  */
+  --afh-space-7xl: 40px;
+  --afh-space-8xl: 48px;
+  --afh-space-9xl: 64px;
+  --afh-space-10xl: 96px;
+
+  /* Layout-level aliases (mobile-first containers) */
+  --afh-page-padding: 12px;
+  --afh-card-padding: 18px;
+  --afh-section-gap: 24px;
+  --afh-container-max: 430px;
+}
+
+@media (min-width: 768px) {
+  :root {
+    --afh-page-padding: 24px;
+    --afh-card-padding: 24px;
+    --afh-section-gap: 32px;
+    --afh-container-max: 720px;
+  }
+}
+
+@media (min-width: 1200px) {
+  :root {
+    --afh-page-padding: 32px;
+    --afh-card-padding: 32px;
+    --afh-section-gap: 48px;
+    --afh-container-max: 800px;
+  }
+}

--- a/src/styles/tokens/type.css
+++ b/src/styles/tokens/type.css
@@ -1,0 +1,95 @@
+/* ============================================================
+   Africa History — Typography Tokens
+   ETNI-21 · UX-DR2, UX-DR3, UX-DR48
+   ------------------------------------------------------------
+   Fraunces (--font-fraunces) and Nunito Sans (--font-nunito-sans)
+   are loaded by `src/app/layout.tsx` via `next/font/google` —
+   these tokens layer a 9-role scale on top.
+
+   9-role scale: hero / h1 / h2 / h3 / body / small / caption /
+                 micro / nano
+
+   Mobile-first base (430 px) with two scale-up breakpoints:
+     · tablet  ≥ 768 px
+     · desktop ≥ 1200 px
+
+   Density profiles (UX-DR48):
+     reading    — generous line-height (1.65), public fiches
+     moderation — compact (1.45), admin tables
+     developer  — monospaced lookalike (1.35), debug surfaces
+   ============================================================ */
+
+:root {
+  /* ─── Font families ───────────────────────────────────────── */
+  --afh-font-display: var(--font-fraunces), "Fraunces", Georgia, serif;
+  --afh-font-body:
+    var(--font-nunito-sans), "Nunito Sans", system-ui, sans-serif;
+  --afh-font-mono:
+    "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, monospace;
+
+  /* ─── 9-role scale · mobile (≥ 430 px base) ───────────────── */
+  --afh-text-hero: 34px;
+  --afh-text-h1: 24px;
+  --afh-text-h2: 18px;
+  --afh-text-h3: 16px;
+  --afh-text-body: 14px;
+  --afh-text-small: 12px;
+  --afh-text-caption: 11px;
+  --afh-text-micro: 10px;
+  --afh-text-nano: 9px;
+
+  /* ─── Weights ─────────────────────────────────────────────── */
+  --afh-weight-regular: 400;
+  --afh-weight-medium: 500;
+  --afh-weight-semibold: 600;
+  --afh-weight-bold: 700;
+  --afh-weight-heavy: 800;
+  --afh-weight-black: 900;
+
+  /* ─── Line-heights ────────────────────────────────────────── */
+  --afh-leading-tight: 1.2;
+  --afh-leading-snug: 1.35;
+  --afh-leading-normal: 1.5;
+  --afh-leading-relaxed: 1.65;
+
+  /* ─── Letter-spacing ──────────────────────────────────────── */
+  --afh-tracking-tight: -0.01em;
+  --afh-tracking-normal: 0;
+  --afh-tracking-wide: 0.05em;
+  --afh-tracking-wider: 0.1em;
+
+  /* ─── Density profiles (UX-DR48) ──────────────────────────── */
+  --afh-density-reading: var(--afh-leading-relaxed);
+  --afh-density-moderation: var(--afh-leading-snug);
+  --afh-density-developer: var(--afh-leading-snug);
+}
+
+/* ─── Tablet (≥ 768 px) ───────────────────────────────────── */
+@media (min-width: 768px) {
+  :root {
+    --afh-text-hero: 44px;
+    --afh-text-h1: 30px;
+    --afh-text-h2: 22px;
+    --afh-text-h3: 18px;
+    --afh-text-body: 15px;
+    --afh-text-small: 13px;
+    --afh-text-caption: 12px;
+    --afh-text-micro: 11px;
+    --afh-text-nano: 10px;
+  }
+}
+
+/* ─── Desktop (≥ 1200 px) ─────────────────────────────────── */
+@media (min-width: 1200px) {
+  :root {
+    --afh-text-hero: 56px;
+    --afh-text-h1: 36px;
+    --afh-text-h2: 24px;
+    --afh-text-h3: 20px;
+    --afh-text-body: 16px;
+    --afh-text-small: 14px;
+    --afh-text-caption: 12px;
+    --afh-text-micro: 11px;
+    --afh-text-nano: 10px;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -17,11 +18,78 @@ export default {
       },
     },
     extend: {
+      // ETNI-21: Africa History (`--afh-*`) token surface for Tailwind utilities.
+      // Additive only — existing shadcn HSL tokens below are untouched.
       fontFamily: {
-        sans: ['var(--font-inter)', 'sans-serif'],
-        display: ['var(--font-playfair)', 'serif'],
+        sans: ["var(--font-inter)", "sans-serif"],
+        display: ["var(--font-playfair)", "serif"],
+        afh: ["var(--font-nunito-sans)", "system-ui", "sans-serif"],
+        "afh-display": ["var(--font-fraunces)", "Georgia", "serif"],
+      },
+      fontSize: {
+        "afh-hero": "var(--afh-text-hero)",
+        "afh-h1": "var(--afh-text-h1)",
+        "afh-h2": "var(--afh-text-h2)",
+        "afh-h3": "var(--afh-text-h3)",
+        "afh-body": "var(--afh-text-body)",
+        "afh-small": "var(--afh-text-small)",
+        "afh-caption": "var(--afh-text-caption)",
+        "afh-micro": "var(--afh-text-micro)",
+        "afh-nano": "var(--afh-text-nano)",
+      },
+      spacing: {
+        "afh-xs": "var(--afh-space-xs)",
+        "afh-sm": "var(--afh-space-sm)",
+        "afh-md": "var(--afh-space-md)",
+        "afh-base": "var(--afh-space-base)",
+        "afh-lg": "var(--afh-space-lg)",
+        "afh-xl": "var(--afh-space-xl)",
+        "afh-2xl": "var(--afh-space-2xl)",
+        "afh-3xl": "var(--afh-space-3xl)",
+        "afh-4xl": "var(--afh-space-4xl)",
+        "afh-5xl": "var(--afh-space-5xl)",
+        "afh-6xl": "var(--afh-space-6xl)",
+      },
+      boxShadow: {
+        "afh-1": "var(--afh-elev-1)",
+        "afh-2": "var(--afh-elev-2)",
+        "afh-3": "var(--afh-elev-3)",
+        "afh-4": "var(--afh-elev-4)",
+        "afh-5": "var(--afh-elev-5)",
+        "afh-warm": "var(--afh-elev-warm)",
+      },
+      transitionDuration: {
+        "afh-fast": "120ms",
+        "afh-base": "200ms",
+        "afh-slow": "320ms",
+        "afh-fade": "400ms",
+        "afh-pageload": "600ms",
       },
       colors: {
+        // L2 semantic aliases (ETNI-21). Available as Tailwind utilities
+        // like `bg-afh-conf-high` or `text-afh-source-primary`.
+        "afh-bg": "var(--afh-bg)",
+        "afh-bg-warm": "var(--afh-bg-warm)",
+        "afh-surface": "var(--afh-surface)",
+        "afh-border": "var(--afh-border)",
+        "afh-text": "var(--afh-text)",
+        "afh-text-soft": "var(--afh-text-soft)",
+        "afh-text-muted": "var(--afh-text-muted)",
+        "afh-earth": "var(--afh-earth)",
+        "afh-terracotta": "var(--afh-terracotta)",
+        "afh-gold": "var(--afh-gold)",
+        "afh-conf-high": "var(--afh-conf-high)",
+        "afh-conf-mid": "var(--afh-conf-mid)",
+        "afh-conf-low": "var(--afh-conf-low)",
+        "afh-classification-stable": "var(--afh-classification-stable)",
+        "afh-classification-contested": "var(--afh-classification-contested)",
+        "afh-classification-disputed": "var(--afh-classification-disputed)",
+        "afh-source-primary": "var(--afh-source-primary)",
+        "afh-source-secondary": "var(--afh-source-secondary)",
+        "afh-source-ai-flagged": "var(--afh-source-ai-flagged)",
+        "afh-flag-open": "var(--afh-flag-open)",
+        "afh-flag-resolved": "var(--afh-flag-resolved)",
+        "afh-error": "var(--afh-error)",
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
@@ -70,6 +138,14 @@ export default {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+        // ETNI-21: Africa History radii (additive).
+        "afh-sm": "var(--afh-radius-sm)",
+        "afh-md": "var(--afh-radius-md)",
+        "afh-base": "var(--afh-radius-base)",
+        "afh-lg": "var(--afh-radius-lg)",
+        "afh-xl": "var(--afh-radius-xl)",
+        "afh-2xl": "var(--afh-radius-2xl)",
+        "afh-3xl": "var(--afh-radius-3xl)",
       },
       keyframes: {
         "accordion-down": {
@@ -95,5 +171,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary

- ETNI-21: Africa History design-system tokens + typography foundation.
- New `src/styles/tokens/{color,type,space,elevation,motion,radius}.css` with `--afh-*` prefix.
- 6 MDX pages under `src/stories/design-system/`.
- ESLint rule for `--afh-error` misuse (UX-DR49 rule 3).
- Existing `--country-*` tokens preserved as aliases for one release.

## Refined ACs covered

- `--afh-*` tokens across color / type / space / elevation / motion / radii.
- L2 semantic tokens (confidence-tier, classification-state, source-tier, flag-state, density profiles).
- 9-role type scale (`hero / h1 / h2 / h3 / body / small / caption / micro / nano`) layered on top of the pre-existing Fraunces + Nunito Sans `next/font/google` imports.
- Motion tokens collapse to 0.01 ms opacity-only under `prefers-reduced-motion: reduce`.
- ESLint rule `afh/afh-error-misuse` blocks `--afh-error` references outside files whose name contains `Error` / `Invalid` / `Broken`.
- Storybook MDX pages render under a "Design System" category (Color / Type / Spacing / Elevation / Motion / Radii).

## Notes

- Token imports were added to `src/index.css` (the actual Tailwind entry, imported by `src/app/layout.tsx`). The original ticket referenced `globals.css` — that file does not exist in this codebase.
- The custom ESLint rule lives at `eslint/rules/afh-error-misuse.js` with its plugin wrapper at `eslint/plugins/afh.js`; the `eslint/` directory is excluded from the project ESLint pass because the ESLint plugin API requires CommonJS.
- Tailwind theme extension is additive — `bg-afh-conf-high`, `text-afh-source-primary`, `shadow-afh-2`, etc., are now available as utilities.

## Out of scope (deferred)

- Component refactors to consume `--afh-*` tokens — handled in sibling Epic 1 PRs.
- Removal of `--country-*` tokens — kept for one release as a deprecation alias layer.

## Test plan

- [x] `npm run type-check`
- [x] `npm run build-storybook`
- [x] `node eslint/__tests__/afh-error-misuse.test.js`
- [ ] Toggle `prefers-reduced-motion: reduce` in DevTools → Rendering and verify motion tokens collapse to 0.01 ms
- [ ] Manually verify ESLint rule by referencing `--afh-error` in a non-Error component (should fail lint)
