### PR TITLE
ETNI-31: UnauditedDisclaimer component

### DIFF
--- a/src/components/source-transparency/UnauditedDisclaimer.stories.tsx
+++ b/src/components/source-transparency/UnauditedDisclaimer.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect, useState } from "react";
+import { UnauditedDisclaimer } from "./UnauditedDisclaimer";
+
+const meta: Meta<typeof UnauditedDisclaimer> = {
+  title: "SourceTransparency/UnauditedDisclaimer",
+  component: UnauditedDisclaimer,
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+  argTypes: {
+    lastHumanAuditAt: { control: "text" },
+    fiche: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UnauditedDisclaimer>;
+
+/** Fiche never audited — primary banner copy. */
+export const NeverAudited: Story = {
+  name: "Never audited (null)",
+  args: {
+    lastHumanAuditAt: null,
+    fiche: "PPL_YORUBA",
+  },
+};
+
+/** Audit older than 18 months → stale banner with long French date. */
+export const StaleAudit: Story = {
+  name: "Stale (> 18 months)",
+  args: {
+    lastHumanAuditAt: "2023-09-15T00:00:00.000Z",
+    fiche: "PPL_BAMBARA",
+  },
+};
+
+/** Audit within 18 months → component renders nothing. */
+export const FreshAudit: Story = {
+  name: "Fresh (< 18 months, renders nothing)",
+  args: {
+    lastHumanAuditAt: new Date(
+      Date.now() - 30 * 24 * 60 * 60 * 1000
+    ).toISOString(),
+    fiche: "PPL_FON",
+  },
+};
+
+const DISMISSED_FICHE = "PPL_DISMISSED";
+const DISMISSED_KEY = `unaudited-disclaimer:dismissed:${DISMISSED_FICHE}`;
+
+function DismissedStoryHost(
+  props: React.ComponentProps<typeof UnauditedDisclaimer>
+) {
+  // Seed localStorage *before* the disclaimer mounts so its initial state
+  // reflects the dismissed flag.
+  const [seeded] = useState(() => {
+    if (typeof window === "undefined") return false;
+    window.localStorage.setItem(DISMISSED_KEY, "1");
+    return true;
+  });
+  useEffect(() => {
+    return () => {
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(DISMISSED_KEY);
+      }
+    };
+  }, []);
+  if (!seeded && typeof window !== "undefined") return null;
+  return <UnauditedDisclaimer {...props} />;
+}
+
+/**
+ * Dismissal already persisted in `localStorage` for this fiche — the banner
+ * is suppressed even though the audit state would otherwise trigger it.
+ */
+export const Dismissed: Story = {
+  name: "Dismissed (localStorage)",
+  render: (args) => <DismissedStoryHost {...args} />,
+  args: {
+    lastHumanAuditAt: null,
+    fiche: DISMISSED_FICHE,
+  },
+};

--- a/src/components/source-transparency/UnauditedDisclaimer.tsx
+++ b/src/components/source-transparency/UnauditedDisclaimer.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STALE_THRESHOLD_MONTHS = 18;
+const DISMISS_KEY_PREFIX = "unaudited-disclaimer:dismissed:";
+
+export type UnauditedDisclaimerProps = {
+  /** ISO date string of the last human audit, or `null` if never audited. */
+  lastHumanAuditAt: string | null;
+  /** Fiche identifier (e.g. `PPL_YORUBA`, `FLG_BANTU`, `BFA`). Used as the
+   *  per-fiche localStorage dismiss key. */
+  fiche: string;
+};
+
+function dismissKey(fiche: string): string {
+  return `${DISMISS_KEY_PREFIX}${fiche}`;
+}
+
+function readDismissed(fiche: string): boolean {
+  try {
+    return window.localStorage.getItem(dismissKey(fiche)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeDismissed(fiche: string): void {
+  try {
+    window.localStorage.setItem(dismissKey(fiche), "1");
+  } catch {
+    // SSR or storage disabled — fail silently.
+  }
+}
+
+function monthsBetween(from: Date, to: Date): number {
+  const years = to.getFullYear() - from.getFullYear();
+  const months = to.getMonth() - from.getMonth();
+  const days = to.getDate() - from.getDate();
+  // Subtract one month if `to` hasn't yet reached the same day-of-month.
+  return years * 12 + months - (days < 0 ? 1 : 0);
+}
+
+function formatLongFrenchDate(iso: string): string {
+  const d = new Date(iso);
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(d);
+}
+
+type Variant =
+  | { kind: "none" }
+  | { kind: "never" }
+  | { kind: "stale"; dateLabel: string };
+
+function resolveVariant(lastHumanAuditAt: string | null): Variant {
+  if (lastHumanAuditAt === null) {
+    return { kind: "never" };
+  }
+  const audited = new Date(lastHumanAuditAt);
+  if (Number.isNaN(audited.getTime())) {
+    return { kind: "none" };
+  }
+  const months = monthsBetween(audited, new Date());
+  if (months > STALE_THRESHOLD_MONTHS) {
+    return { kind: "stale", dateLabel: formatLongFrenchDate(lastHumanAuditAt) };
+  }
+  return { kind: "none" };
+}
+
+export function UnauditedDisclaimer({
+  lastHumanAuditAt,
+  fiche,
+}: UnauditedDisclaimerProps) {
+  const variant = resolveVariant(lastHumanAuditAt);
+
+  // Initialise from localStorage synchronously so dismissed fiches never flash
+  // the banner on mount.
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return readDismissed(fiche);
+  });
+
+  // Re-read on fiche change (e.g. when the component is re-used across pages).
+  useEffect(() => {
+    setDismissed(readDismissed(fiche));
+  }, [fiche]);
+
+  if (variant.kind === "none") return null;
+  if (dismissed) return null;
+
+  const message =
+    variant.kind === "never"
+      ? "fiche non auditée — lire avec précaution"
+      : `dernière vérification : ${variant.dateLabel} · à re-vérifier`;
+
+  const handleDismiss = () => {
+    writeDismissed(fiche);
+    setDismissed(true);
+  };
+
+  return (
+    <div
+      role="region"
+      aria-label="avertissement vérification"
+      className="flex items-start justify-between gap-3 rounded-md border px-4 py-3 text-sm"
+      style={{
+        background: "var(--afh-bg-warm, var(--country-bg, #F5EDE0))",
+        borderColor: "var(--country-border, #E8DFD3)",
+        color: "var(--country-text, #2C2018)",
+      }}
+    >
+      <p className="m-0">{message}</p>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="fermer l'avertissement"
+        className="shrink-0 rounded p-1 text-base leading-none hover:opacity-70 focus:outline-none focus-visible:ring-2"
+        style={{ color: "var(--country-text-soft, #7A6B5D)" }}
+      >
+        <span aria-hidden="true">×</span>
+      </button>
+    </div>
+  );
+}
+
+export default UnauditedDisclaimer;

--- a/src/components/source-transparency/__tests__/UnauditedDisclaimer.test.tsx
+++ b/src/components/source-transparency/__tests__/UnauditedDisclaimer.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { UnauditedDisclaimer } from "../UnauditedDisclaimer";
+
+const FICHE = "PPL_YORUBA";
+const DISMISS_KEY = `unaudited-disclaimer:dismissed:${FICHE}`;
+
+describe("UnauditedDisclaimer", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    // Fix "today" for deterministic month-difference math.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    window.localStorage.clear();
+  });
+
+  describe("when lastHumanAuditAt is null", () => {
+    it('renders the "fiche non auditée" banner', () => {
+      render(<UnauditedDisclaimer lastHumanAuditAt={null} fiche={FICHE} />);
+      expect(
+        screen.getByText(/fiche non auditée — lire avec précaution/i)
+      ).toBeTruthy();
+    });
+
+    it("uses role=region with the expected aria-label", () => {
+      render(<UnauditedDisclaimer lastHumanAuditAt={null} fiche={FICHE} />);
+      const region = screen.getByRole("region", {
+        name: /avertissement vérification/i,
+      });
+      expect(region).toBeTruthy();
+    });
+  });
+
+  describe("when lastHumanAuditAt is older than 18 months", () => {
+    it("renders the 'dernière vérification' banner with a long French date", () => {
+      // 2024-05-01 is > 18 months before 2026-05-14
+      render(
+        <UnauditedDisclaimer
+          lastHumanAuditAt="2024-05-01T00:00:00.000Z"
+          fiche={FICHE}
+        />
+      );
+      // Long French date: e.g. "1 mai 2024"
+      expect(
+        screen.getByText(/dernière vérification\s*:\s*1\s+mai\s+2024/i)
+      ).toBeTruthy();
+      expect(screen.getByText(/à re-vérifier/i)).toBeTruthy();
+    });
+  });
+
+  describe("when lastHumanAuditAt is less than 18 months old", () => {
+    it("renders nothing", () => {
+      // 2025-06-01 is ~11 months before 2026-05-14 → fresh
+      const { container } = render(
+        <UnauditedDisclaimer
+          lastHumanAuditAt="2025-06-01T00:00:00.000Z"
+          fiche={FICHE}
+        />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("dismissal", () => {
+    it("writes the dismiss flag to localStorage and unmounts the banner", () => {
+      render(<UnauditedDisclaimer lastHumanAuditAt={null} fiche={FICHE} />);
+      const closeBtn = screen.getByRole("button", {
+        name: /fermer l'avertissement/i,
+      });
+      fireEvent.click(closeBtn);
+
+      expect(window.localStorage.getItem(DISMISS_KEY)).toBe("1");
+      expect(
+        screen.queryByText(/fiche non auditée — lire avec précaution/i)
+      ).toBeNull();
+    });
+
+    it("renders nothing on remount when dismissal is already in localStorage", () => {
+      window.localStorage.setItem(DISMISS_KEY, "1");
+      const { container } = render(
+        <UnauditedDisclaimer lastHumanAuditAt={null} fiche={FICHE} />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("scopes dismissal per fiche", () => {
+      window.localStorage.setItem("unaudited-disclaimer:dismissed:OTHER", "1");
+      render(<UnauditedDisclaimer lastHumanAuditAt={null} fiche={FICHE} />);
+      expect(
+        screen.getByText(/fiche non auditée — lire avec précaution/i)
+      ).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- ETNI-31: banner that signals unaudited or stale fiches.
- New `src/components/source-transparency/UnauditedDisclaimer.tsx` + tests + Storybook story.
- Variants: `lastHumanAuditAt === null` and `> 18 months`. Otherwise: no render.

## Refined ACs covered

- NULL → "fiche non auditée — lire avec précaution".
- > 18 months → "dernière vérification : <long FR date> · à re-vérifier".
- `--afh-bg-warm` background with `--country-bg` fallback (not alarm).
- `role="region"` + `aria-label`.
- Dismissible per-fiche via localStorage key `unaudited-disclaimer:dismissed:<fiche>`.

## Out of scope

- Fiche integration → follow-up PR.
- Confidence-recomputation trigger updating `last_human_audit_at` → ETNI-23.

## Test plan

- [x] `npx vitest run src/components/source-transparency/__tests__/UnauditedDisclaimer.test.tsx`
- [x] `npm run type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
