### PR TITLE
ETNI-32: editorial CI rules

### DIFF
--- a/.github/workflows/editorial-rules.yml
+++ b/.github/workflows/editorial-rules.yml
@@ -3,8 +3,16 @@ name: Editorial Rules Gate
 on:
   pull_request:
     branches: [main, recette]
+    paths:
+      - "dataset/source/afrik/**"
+      - "scripts/ci/checkEditorialRules.ts"
+      - ".github/workflows/editorial-rules.yml"
   push:
     branches: [main, recette]
+    paths:
+      - "dataset/source/afrik/**"
+      - "scripts/ci/checkEditorialRules.ts"
+      - ".github/workflows/editorial-rules.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/editorial-rules.yml
+++ b/.github/workflows/editorial-rules.yml
@@ -1,0 +1,34 @@
+name: Editorial Rules Gate
+
+on:
+  pull_request:
+    branches: [main, recette]
+  push:
+    branches: [main, recette]
+  workflow_dispatch:
+
+jobs:
+  editorial-rules:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      # Enforces three decolonial-posture rules on AFRIK fiches:
+      #   1. autonym required at confidence >= medium (warning otherwise)
+      #   2. >= 2 sources when classification_status is contested or
+      #      colonial-legacy
+      #   3. DoctrineLinkCard snapshot presence — graceful skip when ETNI-28
+      #      is not yet merged
+      # PR annotations are emitted on stdout in GitHub Actions
+      # workflow-command format.
+      - name: Run editorial-rules gate
+        run: npx tsx scripts/ci/checkEditorialRules.ts

--- a/scripts/ci/__tests__/checkEditorialRules.test.ts
+++ b/scripts/ci/__tests__/checkEditorialRules.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import {
+  checkAutonym,
+  checkSourcesCount,
+  checkDoctrineLinkCardSnapshot,
+  extractAutonym,
+  extractConfidence,
+  extractClassificationStatus,
+  extractSources,
+  runEditorialRules,
+  type Fiche,
+  type RuleResult,
+} from "../checkEditorialRules";
+
+describe("checkEditorialRules — helpers", () => {
+  describe("extractAutonym", () => {
+    it("returns the top-level autonym when present", () => {
+      const fiche: Fiche = {
+        id: "PPL_TEST",
+        autonym: "Babemba",
+        content: {},
+      };
+      expect(extractAutonym(fiche)).toBe("Babemba");
+    });
+
+    it("falls back to content.appellations.selfAppellation for PPL fiches", () => {
+      const fiche: Fiche = {
+        id: "PPL_TEST",
+        content: {
+          appellations: { selfAppellation: "Baganda (sg. Muganda)" },
+        },
+      };
+      expect(extractAutonym(fiche)).toBe("Baganda (sg. Muganda)");
+    });
+
+    it("falls back to content.decolonialHeader.selfAppellation for FLG fiches", () => {
+      const fiche: Fiche = {
+        id: "FLG_TEST",
+        content: {
+          decolonialHeader: { selfAppellation: "Bantu" },
+        },
+      };
+      expect(extractAutonym(fiche)).toBe("Bantu");
+    });
+
+    it("returns null when no autonym source is present", () => {
+      const fiche: Fiche = { id: "PPL_X", content: {} };
+      expect(extractAutonym(fiche)).toBeNull();
+    });
+
+    it("returns null when selfAppellation is empty string", () => {
+      const fiche: Fiche = {
+        id: "PPL_X",
+        content: { appellations: { selfAppellation: "" } },
+      };
+      expect(extractAutonym(fiche)).toBeNull();
+    });
+  });
+
+  describe("extractConfidence", () => {
+    it("returns top-level confidence value", () => {
+      const fiche: Fiche = { id: "PPL_X", confidence: "high", content: {} };
+      expect(extractConfidence(fiche)).toBe("high");
+    });
+
+    it("returns null when not set", () => {
+      expect(extractConfidence({ id: "PPL_X", content: {} })).toBeNull();
+    });
+  });
+
+  describe("extractClassificationStatus", () => {
+    it("returns top-level classification_status value", () => {
+      const fiche: Fiche = {
+        id: "PPL_X",
+        classification_status: "contested",
+        content: {},
+      };
+      expect(extractClassificationStatus(fiche)).toBe("contested");
+    });
+
+    it("returns null when not set", () => {
+      expect(
+        extractClassificationStatus({ id: "PPL_X", content: {} })
+      ).toBeNull();
+    });
+  });
+
+  describe("extractSources", () => {
+    it("returns content.sources array length", () => {
+      const fiche: Fiche = {
+        id: "PPL_X",
+        content: { sources: ["a", "b", "c"] },
+      };
+      expect(extractSources(fiche)).toEqual(["a", "b", "c"]);
+    });
+
+    it("returns empty array when sources is missing", () => {
+      expect(extractSources({ id: "PPL_X", content: {} })).toEqual([]);
+    });
+  });
+});
+
+describe("checkAutonym (Rule 1)", () => {
+  it("passes when autonym is present, regardless of confidence", () => {
+    const fiche: Fiche = {
+      id: "PPL_X",
+      confidence: "high",
+      content: { appellations: { selfAppellation: "Test" } },
+    };
+    const r = checkAutonym(fiche, "PPL_X.json");
+    expect(r).toBeNull();
+  });
+
+  it("warns when autonym missing and confidence < medium", () => {
+    const fiche: Fiche = { id: "PPL_X", confidence: "low", content: {} };
+    const r = checkAutonym(fiche, "PPL_X.json");
+    expect(r).not.toBeNull();
+    expect(r!.severity).toBe("warning");
+    expect(r!.rule).toBe("autonym-required");
+    expect(r!.file).toBe("PPL_X.json");
+    expect(r!.slug).toBe("PPL_X");
+  });
+
+  it("errors when autonym missing and confidence >= medium", () => {
+    const fiche: Fiche = { id: "PPL_X", confidence: "medium", content: {} };
+    const r = checkAutonym(fiche, "PPL_X.json");
+    expect(r).not.toBeNull();
+    expect(r!.severity).toBe("error");
+  });
+
+  it("errors when autonym missing and confidence = high", () => {
+    const fiche: Fiche = { id: "PPL_X", confidence: "high", content: {} };
+    const r = checkAutonym(fiche, "PPL_X.json");
+    expect(r!.severity).toBe("error");
+  });
+
+  it("warns (not errors) when autonym missing and confidence is null/missing", () => {
+    const fiche: Fiche = { id: "PPL_X", content: {} };
+    const r = checkAutonym(fiche, "PPL_X.json");
+    expect(r!.severity).toBe("warning");
+  });
+
+  it("exempts country fiches (paths under pays/) from the autonym rule", () => {
+    const fiche: Fiche = { id: "MAR", confidence: "high", content: {} };
+    const r = checkAutonym(fiche, "dataset/source/afrik/pays/MAR.json");
+    expect(r).toBeNull();
+  });
+});
+
+describe("checkSourcesCount (Rule 2)", () => {
+  it("passes when classification_status is not contested/colonial-legacy", () => {
+    const fiche: Fiche = {
+      id: "PPL_X",
+      classification_status: "stable",
+      content: { sources: [] },
+    };
+    expect(checkSourcesCount(fiche, "PPL_X.json")).toBeNull();
+  });
+
+  it("passes when classification_status is missing", () => {
+    const fiche: Fiche = { id: "PPL_X", content: { sources: [] } };
+    expect(checkSourcesCount(fiche, "PPL_X.json")).toBeNull();
+  });
+
+  it("passes when contested and sources.length >= 2", () => {
+    const fiche: Fiche = {
+      id: "PPL_X",
+      classification_status: "contested",
+      content: { sources: ["a", "b"] },
+    };
+    expect(checkSourcesCount(fiche, "PPL_X.json")).toBeNull();
+  });
+
+  it("errors when contested and sources.length < 2", () => {
+    const fiche: Fiche = {
+      id: "PPL_X",
+      classification_status: "contested",
+      content: { sources: ["only-one"] },
+    };
+    const r = checkSourcesCount(fiche, "PPL_X.json");
+    expect(r).not.toBeNull();
+    expect(r!.severity).toBe("error");
+    expect(r!.rule).toBe("sources-count");
+    expect(r!.slug).toBe("PPL_X");
+  });
+
+  it("errors when colonial-legacy and sources.length < 2", () => {
+    const fiche: Fiche = {
+      id: "PPL_X",
+      classification_status: "colonial-legacy",
+      content: {},
+    };
+    const r = checkSourcesCount(fiche, "PPL_X.json");
+    expect(r!.severity).toBe("error");
+  });
+});
+
+describe("checkDoctrineLinkCardSnapshot (Rule 3)", () => {
+  let tmpRepoRoot: string;
+
+  beforeEach(() => {
+    tmpRepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "etni32-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRepoRoot, { recursive: true, force: true });
+  });
+
+  it("returns a notice (severity=notice) when no DoctrineLinkCard test exists anywhere", () => {
+    // Empty repo — no DoctrineLinkCard reference anywhere
+    fs.mkdirSync(path.join(tmpRepoRoot, "src"));
+    const r = checkDoctrineLinkCardSnapshot(
+      { id: "PPL_X", classification_status: "contested", content: {} },
+      "PPL_X.json",
+      tmpRepoRoot
+    );
+    expect(r).not.toBeNull();
+    expect(r!.severity).toBe("notice");
+    expect(r!.rule).toBe("doctrine-link-card-snapshot");
+  });
+
+  it("skips fiches that are not contested/colonial-legacy", () => {
+    const r = checkDoctrineLinkCardSnapshot(
+      { id: "PPL_X", content: {} },
+      "PPL_X.json",
+      tmpRepoRoot
+    );
+    expect(r).toBeNull();
+  });
+
+  it("passes when a test file referencing DoctrineLinkCard exists", () => {
+    const testDir = path.join(tmpRepoRoot, "src", "components");
+    fs.mkdirSync(testDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(testDir, "Section.test.tsx"),
+      "import { DoctrineLinkCard } from '@/components/DoctrineLinkCard';\nexpect(...).toContain('DoctrineLinkCard');"
+    );
+    const r = checkDoctrineLinkCardSnapshot(
+      { id: "PPL_X", classification_status: "contested", content: {} },
+      "PPL_X.json",
+      tmpRepoRoot
+    );
+    expect(r).toBeNull();
+  });
+});
+
+describe("runEditorialRules — end-to-end", () => {
+  let tmpRoot: string;
+  let datasetDir: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "etni32-e2e-"));
+    datasetDir = path.join(tmpRoot, "dataset", "source", "afrik");
+    fs.mkdirSync(path.join(datasetDir, "peuples", "FLG_BANTU"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(datasetDir, "famille_linguistique"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(datasetDir, "pays"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function writeFiche(relPath: string, fiche: object): void {
+    const full = path.join(datasetDir, relPath);
+    fs.writeFileSync(full, JSON.stringify(fiche, null, 2));
+  }
+
+  it("returns exitCode 0 with no findings on clean dataset", () => {
+    writeFiche("peuples/FLG_BANTU/PPL_CLEAN.json", {
+      id: "PPL_CLEAN",
+      content: {
+        appellations: { selfAppellation: "Test endonym" },
+        sources: ["one", "two"],
+      },
+    });
+    const r = runEditorialRules({ repoRoot: tmpRoot });
+    expect(r.exitCode).toBe(0);
+    // Only notices allowed
+    expect(r.findings.filter((f) => f.severity !== "notice")).toHaveLength(0);
+  });
+
+  it("returns non-zero exitCode when a Rule 1 error is detected", () => {
+    writeFiche("peuples/FLG_BANTU/PPL_BAD.json", {
+      id: "PPL_BAD",
+      confidence: "high",
+      content: { sources: ["a"] },
+    });
+    const r = runEditorialRules({ repoRoot: tmpRoot });
+    expect(r.exitCode).toBe(1);
+    expect(
+      r.findings.some(
+        (f) => f.rule === "autonym-required" && f.severity === "error"
+      )
+    ).toBe(true);
+  });
+
+  it("returns exitCode 0 when only a Rule 1 warning is detected", () => {
+    writeFiche("peuples/FLG_BANTU/PPL_WARN.json", {
+      id: "PPL_WARN",
+      confidence: "low",
+      content: { sources: ["a", "b"] },
+    });
+    const r = runEditorialRules({ repoRoot: tmpRoot });
+    expect(r.exitCode).toBe(0);
+    expect(
+      r.findings.some(
+        (f) => f.rule === "autonym-required" && f.severity === "warning"
+      )
+    ).toBe(true);
+  });
+
+  it("returns non-zero exitCode when a Rule 2 error is detected", () => {
+    writeFiche("peuples/FLG_BANTU/PPL_CONTESTED.json", {
+      id: "PPL_CONTESTED",
+      classification_status: "contested",
+      content: {
+        appellations: { selfAppellation: "Endonym present" },
+        sources: ["only-one"],
+      },
+    });
+    const r = runEditorialRules({ repoRoot: tmpRoot });
+    expect(r.exitCode).toBe(1);
+    expect(
+      r.findings.some(
+        (f) => f.rule === "sources-count" && f.severity === "error"
+      )
+    ).toBe(true);
+  });
+
+  it("emits a notice (not error) for Rule 3 when DoctrineLinkCard test is missing", () => {
+    writeFiche("peuples/FLG_BANTU/PPL_COLONIAL.json", {
+      id: "PPL_COLONIAL",
+      classification_status: "colonial-legacy",
+      content: {
+        appellations: { selfAppellation: "Endonym present" },
+        sources: ["a", "b"],
+      },
+    });
+    const r = runEditorialRules({ repoRoot: tmpRoot });
+    expect(r.exitCode).toBe(0);
+    expect(
+      r.findings.some(
+        (f) =>
+          f.rule === "doctrine-link-card-snapshot" && f.severity === "notice"
+      )
+    ).toBe(true);
+  });
+
+  it("emits PR-annotation lines for every finding", () => {
+    writeFiche("peuples/FLG_BANTU/PPL_BAD.json", {
+      id: "PPL_BAD",
+      confidence: "high",
+      content: { sources: ["a"] },
+    });
+    const r = runEditorialRules({ repoRoot: tmpRoot });
+    expect(r.annotations.length).toBeGreaterThan(0);
+    expect(r.annotations.some((line) => line.startsWith("::error"))).toBe(true);
+    // Every annotation must reference the fiche path and the rule
+    expect(r.annotations.some((line) => line.includes("PPL_BAD.json"))).toBe(
+      true
+    );
+    expect(
+      r.annotations.some((line) => line.includes("autonym-required"))
+    ).toBe(true);
+  });
+
+  it("handles malformed JSON gracefully without crashing", () => {
+    fs.writeFileSync(
+      path.join(datasetDir, "peuples", "FLG_BANTU", "PPL_BROKEN.json"),
+      "{ not valid json"
+    );
+    const r = runEditorialRules({ repoRoot: tmpRoot });
+    // Treated as an error finding rather than a crash
+    expect(
+      r.findings.some((f) => f.rule === "json-parse" && f.severity === "error")
+    ).toBe(true);
+    expect(r.exitCode).toBe(1);
+  });
+});
+
+// Type-check helper: the RuleResult type should be exported and shaped as
+// expected.
+const _typeCheck: RuleResult = {
+  rule: "autonym-required",
+  severity: "warning",
+  file: "x",
+  slug: "x",
+  message: "x",
+};
+void _typeCheck;

--- a/scripts/ci/__tests__/checkEditorialRules.test.ts
+++ b/scripts/ci/__tests__/checkEditorialRules.test.ts
@@ -6,10 +6,12 @@ import {
   checkAutonym,
   checkSourcesCount,
   checkDoctrineLinkCardSnapshot,
+  escapeWorkflowCommand,
   extractAutonym,
   extractConfidence,
   extractClassificationStatus,
   extractSources,
+  formatAnnotation,
   runEditorialRules,
   type Fiche,
   type RuleResult,
@@ -382,6 +384,73 @@ describe("runEditorialRules — end-to-end", () => {
       r.findings.some((f) => f.rule === "json-parse" && f.severity === "error")
     ).toBe(true);
     expect(r.exitCode).toBe(1);
+  });
+});
+
+describe("escapeWorkflowCommand", () => {
+  it("escapes % first to avoid double-escaping later substitutions", () => {
+    expect(escapeWorkflowCommand("100%")).toBe("100%25");
+  });
+
+  it("escapes carriage return and newline", () => {
+    expect(escapeWorkflowCommand("a\r\nb")).toBe("a%0D%0Ab");
+  });
+
+  it("escapes colon and comma", () => {
+    expect(escapeWorkflowCommand("a,b:c")).toBe("a%2Cb%3Ac");
+  });
+
+  it("escapes all special chars together with correct ordering", () => {
+    // % must be escaped first; a literal `%0A` in the input becomes `%250A`,
+    // not a real newline.
+    expect(escapeWorkflowCommand("%0A\n,:")).toBe("%250A%0A%2C%3A");
+  });
+});
+
+describe("formatAnnotation — workflow-command safety", () => {
+  it("escapes commas and colons in the title", () => {
+    const r: RuleResult = {
+      rule: "autonym-required",
+      severity: "error",
+      file: "dataset/source/afrik/peuples/FLG_BANTU/PPL_X.json",
+      slug: "PPL_X,evil::injection",
+      message: "boom",
+    };
+    const line = formatAnnotation(r);
+    // The raw `,` and `::` must not appear inside the title segment — they
+    // would otherwise let a crafted slug forge a fake annotation field.
+    expect(line).toContain(
+      "title=autonym-required%3A%3APPL_X%2Cevil%3A%3Ainjection"
+    );
+    expect(line).not.toContain("title=autonym-required::PPL_X,");
+  });
+
+  it("escapes newlines and percent signs in the message", () => {
+    const r: RuleResult = {
+      rule: "sources-count",
+      severity: "warning",
+      file: "x.json",
+      slug: "PPL_Y",
+      message: "line1\nline2 100%",
+    };
+    const line = formatAnnotation(r);
+    expect(line).toContain("%0A");
+    expect(line).toContain("100%25");
+    expect(line).not.toMatch(/\n/);
+  });
+
+  it("preserves file path with forward slashes and does not escape it", () => {
+    const r: RuleResult = {
+      rule: "autonym-required",
+      severity: "error",
+      file: "dataset/source/afrik/peuples/FLG_BANTU/PPL_X.json",
+      slug: "PPL_X",
+      message: "msg",
+    };
+    const line = formatAnnotation(r);
+    expect(line).toContain(
+      "file=dataset/source/afrik/peuples/FLG_BANTU/PPL_X.json"
+    );
   });
 });
 

--- a/scripts/ci/checkEditorialRules.ts
+++ b/scripts/ci/checkEditorialRules.ts
@@ -310,6 +310,20 @@ function loadFiche(fullPath: string, repoRoot: string): LoadedFiche {
 
 // ───── PR-annotation emitter ──────────────────────────────────────────────
 
+/**
+ * Escape characters that have special meaning in GitHub Actions workflow
+ * commands. The `%` substitution MUST run first to avoid double-escaping.
+ * See https://docs.github.com/actions/reference/workflow-commands-for-github-actions
+ */
+export function escapeWorkflowCommand(s: string): string {
+  return s
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A")
+    .replace(/:/g, "%3A")
+    .replace(/,/g, "%2C");
+}
+
 export function formatAnnotation(r: RuleResult): string {
   const tag =
     r.severity === "error"
@@ -319,7 +333,9 @@ export function formatAnnotation(r: RuleResult): string {
         : "::notice";
   // Posix-style separator for GitHub Actions annotations.
   const file = r.file.split(path.sep).join("/");
-  return `${tag} file=${file},title=${r.rule}::${r.slug} — ${r.message}`;
+  const title = escapeWorkflowCommand(`${r.rule}::${r.slug}`);
+  const message = escapeWorkflowCommand(`${r.slug} — ${r.message}`);
+  return `${tag} file=${file},title=${title}::${message}`;
 }
 
 // ───── Runner ─────────────────────────────────────────────────────────────
@@ -403,6 +419,11 @@ async function main(): Promise<void> {
     process.stdout.write(line + "\n");
   }
   process.stderr.write(summarize(result.findings) + "\n");
+  // Ensure stdout is flushed before exit; process.exit() can otherwise drop
+  // buffered annotation lines and break GitHub Actions parsing.
+  await new Promise<void>((resolve) =>
+    process.stdout.write("", () => resolve())
+  );
   process.exit(result.exitCode);
 }
 

--- a/scripts/ci/checkEditorialRules.ts
+++ b/scripts/ci/checkEditorialRules.ts
@@ -1,0 +1,417 @@
+#!/usr/bin/env tsx
+/**
+ * Editorial CI rules gate for AFRIK fiches — ETNI-32.
+ *
+ * Enforces three decolonial-posture rules on every fiche under
+ * `dataset/source/afrik/`:
+ *
+ *   Rule 1 — Endonym (autonym) required.
+ *     If a fiche has no autonym (top-level `autonym`, or
+ *     `content.appellations.selfAppellation` for PPL fiches, or
+ *     `content.decolonialHeader.selfAppellation` for FLG fiches), then:
+ *       - if `confidence` >= medium → error (blocks merge)
+ *       - if `confidence` < medium or missing → warning (advisory)
+ *
+ *   Rule 2 — Sources count.
+ *     If `classification_status` ∈ {contested, colonial-legacy} and the
+ *     fiche carries fewer than 2 sources (aggregated `content.sources`),
+ *     emit an error.
+ *
+ *   Rule 3 — DoctrineLinkCard snapshot presence.
+ *     If `classification_status` ∈ {contested, colonial-legacy}, look for a
+ *     test file in the repo referencing `DoctrineLinkCard`. If no such test
+ *     exists anywhere (ETNI-28 not yet merged), emit a `notice` and DO NOT
+ *     block the build.
+ *
+ * Output: PR-annotation lines printed to stdout for GitHub Actions to pick
+ * up, plus a human-readable summary on stderr. Exit code 0 when no errors,
+ * 1 otherwise.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { pathToFileURL } from "url";
+
+// ───── Types ──────────────────────────────────────────────────────────────
+
+export type Severity = "error" | "warning" | "notice";
+
+export type RuleName =
+  | "autonym-required"
+  | "sources-count"
+  | "doctrine-link-card-snapshot"
+  | "json-parse";
+
+export interface RuleResult {
+  rule: RuleName;
+  severity: Severity;
+  file: string; // path relative to repo root
+  slug: string; // fiche id, e.g. PPL_YORUBA
+  message: string;
+}
+
+export interface Fiche {
+  id?: string;
+  autonym?: string | null;
+  confidence?: string | null;
+  classification_status?: string | null;
+  content?: {
+    appellations?: { selfAppellation?: string | null };
+    decolonialHeader?: { selfAppellation?: string | null };
+    sources?: unknown[];
+  };
+  [key: string]: unknown;
+}
+
+export interface RunResult {
+  exitCode: number;
+  findings: RuleResult[];
+  annotations: string[];
+}
+
+// ───── Helpers ────────────────────────────────────────────────────────────
+
+const AUTONYM_RULE: RuleName = "autonym-required";
+const SOURCES_RULE: RuleName = "sources-count";
+const DOCTRINE_RULE: RuleName = "doctrine-link-card-snapshot";
+
+const CONFIDENCE_BLOCKING = new Set(["medium", "high", "verified"]);
+const CLASSIFICATION_FLAGGED = new Set(["contested", "colonial-legacy"]);
+
+export function extractAutonym(fiche: Fiche): string | null {
+  const top = fiche.autonym;
+  if (typeof top === "string" && top.trim().length > 0) return top;
+
+  const appellations = fiche.content?.appellations?.selfAppellation;
+  if (typeof appellations === "string" && appellations.trim().length > 0) {
+    return appellations;
+  }
+
+  const flg = fiche.content?.decolonialHeader?.selfAppellation;
+  if (typeof flg === "string" && flg.trim().length > 0) return flg;
+
+  return null;
+}
+
+/**
+ * Country fiches (under `pays/`) don't carry a single autonym — they aggregate
+ * many peoples, each with their own `selfAppellation`. The endonym rule (Rule
+ * 1) only applies to ethnographic entities (peoples, language families).
+ */
+export function isCountryFiche(relPath: string): boolean {
+  const parts = relPath.split(/[\\/]/);
+  return parts.some((p) => p === "pays");
+}
+
+export function extractConfidence(fiche: Fiche): string | null {
+  const c = fiche.confidence;
+  return typeof c === "string" && c.length > 0 ? c.toLowerCase() : null;
+}
+
+export function extractClassificationStatus(fiche: Fiche): string | null {
+  const s = fiche.classification_status;
+  return typeof s === "string" && s.length > 0 ? s.toLowerCase() : null;
+}
+
+export function extractSources(fiche: Fiche): unknown[] {
+  const sources = fiche.content?.sources;
+  return Array.isArray(sources) ? sources : [];
+}
+
+function getSlug(fiche: Fiche, fallbackFromPath: string): string {
+  if (typeof fiche.id === "string" && fiche.id.length > 0) return fiche.id;
+  return path.basename(fallbackFromPath, ".json");
+}
+
+// ───── Rule 1: autonym ────────────────────────────────────────────────────
+
+export function checkAutonym(fiche: Fiche, file: string): RuleResult | null {
+  // Country fiches are exempt — they aggregate many peoples and have no
+  // single autonym.
+  if (isCountryFiche(file)) return null;
+
+  const autonym = extractAutonym(fiche);
+  if (autonym !== null) return null;
+
+  const confidence = extractConfidence(fiche);
+  const blocking = confidence !== null && CONFIDENCE_BLOCKING.has(confidence);
+  const slug = getSlug(fiche, file);
+  const severity: Severity = blocking ? "error" : "warning";
+  const confidenceLabel = confidence ?? "missing";
+
+  return {
+    rule: AUTONYM_RULE,
+    severity,
+    file,
+    slug,
+    message: `Fiche ${slug} has no autonym (endonym). Confidence=${confidenceLabel}. Decolonial posture requires every fiche to provide its self-appellation before reaching confidence >= medium.`,
+  };
+}
+
+// ───── Rule 2: sources count ──────────────────────────────────────────────
+
+export function checkSourcesCount(
+  fiche: Fiche,
+  file: string
+): RuleResult | null {
+  const status = extractClassificationStatus(fiche);
+  if (status === null || !CLASSIFICATION_FLAGGED.has(status)) return null;
+
+  const count = extractSources(fiche).length;
+  if (count >= 2) return null;
+
+  const slug = getSlug(fiche, file);
+  return {
+    rule: SOURCES_RULE,
+    severity: "error",
+    file,
+    slug,
+    message: `Fiche ${slug} has classification_status="${status}" but only ${count} source(s). Decolonial posture requires >= 2 sources for contested or colonial-legacy classifications.`,
+  };
+}
+
+// ───── Rule 3: DoctrineLinkCard snapshot ──────────────────────────────────
+
+const TEST_DIR_NAMES = new Set(["__tests__", "__snapshots__", "tests", "test"]);
+const TEST_FILE_RE = /\.(test|spec|stories)\.(ts|tsx|js|jsx|mdx)$/i;
+const SNAPSHOT_FILE_RE = /\.snap$/i;
+
+function isTestFile(name: string): boolean {
+  return TEST_FILE_RE.test(name) || SNAPSHOT_FILE_RE.test(name);
+}
+
+const IGNORED_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".next",
+  "dist",
+  "build",
+  "coverage",
+  ".cache",
+  ".vercel",
+  ".storybook-static",
+  "storybook-static",
+]);
+
+function searchForDoctrineLinkCardTest(root: string): boolean {
+  // Walk repo, look for a test file mentioning DoctrineLinkCard.
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith(".") && entry.name !== ".github") {
+        // Skip hidden dirs other than .github (not relevant for tests anyway).
+        if (entry.isDirectory()) continue;
+      }
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (IGNORED_DIRS.has(entry.name)) continue;
+        stack.push(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (!isTestFile(entry.name)) continue;
+      let content: string;
+      try {
+        content = fs.readFileSync(full, "utf-8");
+      } catch {
+        continue;
+      }
+      if (content.includes("DoctrineLinkCard")) return true;
+    }
+  }
+  return false;
+}
+
+// Cache to avoid walking the tree per-fiche. Keyed by repoRoot.
+const doctrineSearchCache = new Map<string, boolean>();
+
+export function checkDoctrineLinkCardSnapshot(
+  fiche: Fiche,
+  file: string,
+  repoRoot: string
+): RuleResult | null {
+  const status = extractClassificationStatus(fiche);
+  if (status === null || !CLASSIFICATION_FLAGGED.has(status)) return null;
+
+  let exists = doctrineSearchCache.get(repoRoot);
+  if (exists === undefined) {
+    exists = searchForDoctrineLinkCardTest(repoRoot);
+    doctrineSearchCache.set(repoRoot, exists);
+  }
+
+  if (exists) return null;
+
+  const slug = getSlug(fiche, file);
+  return {
+    rule: DOCTRINE_RULE,
+    severity: "notice",
+    file,
+    slug,
+    message: `Fiche ${slug} has classification_status="${status}" but no DoctrineLinkCard test was found in the repository. ETNI-28 not yet merged — Rule 3 is informational only.`,
+  };
+}
+
+// ───── Loader ─────────────────────────────────────────────────────────────
+
+interface LoadedFiche {
+  fiche: Fiche | null;
+  relPath: string;
+  parseError: string | null;
+}
+
+function listFicheFiles(afrikRoot: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [afrikRoot];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Skip `archive/` directories that are not part of live data.
+        if (entry.name === "archive") continue;
+        stack.push(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith(".json")) continue;
+      out.push(full);
+    }
+  }
+  return out.sort();
+}
+
+function loadFiche(fullPath: string, repoRoot: string): LoadedFiche {
+  const relPath = path.relative(repoRoot, fullPath);
+  try {
+    const raw = fs.readFileSync(fullPath, "utf-8");
+    const fiche = JSON.parse(raw) as Fiche;
+    return { fiche, relPath, parseError: null };
+  } catch (err) {
+    return {
+      fiche: null,
+      relPath,
+      parseError: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ───── PR-annotation emitter ──────────────────────────────────────────────
+
+export function formatAnnotation(r: RuleResult): string {
+  const tag =
+    r.severity === "error"
+      ? "::error"
+      : r.severity === "warning"
+        ? "::warning"
+        : "::notice";
+  // Posix-style separator for GitHub Actions annotations.
+  const file = r.file.split(path.sep).join("/");
+  return `${tag} file=${file},title=${r.rule}::${r.slug} — ${r.message}`;
+}
+
+// ───── Runner ─────────────────────────────────────────────────────────────
+
+export interface RunOptions {
+  repoRoot: string;
+  afrikRoot?: string;
+}
+
+export function runEditorialRules(opts: RunOptions): RunResult {
+  const repoRoot = opts.repoRoot;
+  const afrikRoot =
+    opts.afrikRoot ?? path.join(repoRoot, "dataset", "source", "afrik");
+
+  // Reset doctrine cache for this run (tests reuse the module).
+  doctrineSearchCache.delete(repoRoot);
+
+  const findings: RuleResult[] = [];
+
+  if (!fs.existsSync(afrikRoot)) {
+    // No data dir → nothing to do; emit a notice for transparency but exit 0.
+    const notice: RuleResult = {
+      rule: AUTONYM_RULE,
+      severity: "notice",
+      file: path.relative(repoRoot, afrikRoot),
+      slug: "—",
+      message: `AFRIK source directory not found at ${afrikRoot}; nothing to validate.`,
+    };
+    const annotations = [formatAnnotation(notice)];
+    return { exitCode: 0, findings: [notice], annotations };
+  }
+
+  const files = listFicheFiles(afrikRoot);
+
+  for (const fullPath of files) {
+    const { fiche, relPath, parseError } = loadFiche(fullPath, repoRoot);
+    if (parseError !== null || fiche === null) {
+      findings.push({
+        rule: "json-parse",
+        severity: "error",
+        file: relPath,
+        slug: path.basename(relPath, ".json"),
+        message: `Invalid JSON in ${relPath}: ${parseError}`,
+      });
+      continue;
+    }
+
+    const r1 = checkAutonym(fiche, relPath);
+    if (r1) findings.push(r1);
+
+    const r2 = checkSourcesCount(fiche, relPath);
+    if (r2) findings.push(r2);
+
+    const r3 = checkDoctrineLinkCardSnapshot(fiche, relPath, repoRoot);
+    if (r3) findings.push(r3);
+  }
+
+  const annotations = findings.map(formatAnnotation);
+  const exitCode = findings.some((f) => f.severity === "error") ? 1 : 0;
+  return { exitCode, findings, annotations };
+}
+
+// ───── CLI entry point ────────────────────────────────────────────────────
+
+function summarize(findings: RuleResult[]): string {
+  const counts: Record<Severity, number> = {
+    error: 0,
+    warning: 0,
+    notice: 0,
+  };
+  for (const f of findings) counts[f.severity]++;
+  return `Editorial rules summary — errors: ${counts.error}, warnings: ${counts.warning}, notices: ${counts.notice}`;
+}
+
+async function main(): Promise<void> {
+  const repoRoot = process.cwd();
+  const result = runEditorialRules({ repoRoot });
+  for (const line of result.annotations) {
+    // PR annotations must be written to stdout for GitHub Actions to pick
+    // them up.
+    process.stdout.write(line + "\n");
+  }
+  process.stderr.write(summarize(result.findings) + "\n");
+  process.exit(result.exitCode);
+}
+
+// Only run main() when invoked directly (not when imported by tests).
+const invokedDirectly =
+  typeof process !== "undefined" &&
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  void main();
+}


### PR DESCRIPTION
## Summary

- ETNI-32: CI gate enforcing decolonial editorial rules on AFRIK fiches.
- New `scripts/ci/checkEditorialRules.ts` + new workflow `.github/workflows/editorial-rules.yml`.
- 3 rules: autonym required at confidence >= medium; >= 2 sources on `contested` / `colonial-legacy` fiches; `DoctrineLinkCard` snapshot presence (skips cleanly when ETNI-28 not yet merged).

## Refined ACs covered

- **Rule 1 (autonym):** warning at confidence < medium, error at confidence >= medium. Detects `top-level autonym`, `content.appellations.selfAppellation` (PPL), and `content.decolonialHeader.selfAppellation` (FLG). Country fiches under `pays/` are exempt — they aggregate many peoples and have no single autonym.
- **Rule 2 (sources count):** errors when `classification_status` in `{contested, colonial-legacy}` AND `content.sources.length < 2`.
- **Rule 3 (DoctrineLinkCard):** snapshot presence check via repo-wide grep on test files (`*.test.ts(x)`, `*.spec.ts(x)`, `*.stories.{ts,tsx,mdx}`, `*.snap`). When no test file references `DoctrineLinkCard`, emits a single `::notice` and exits 0 — does **not** block the build.
- **PR-annotation output:** `::error file=...,title=<rule>::<slug> — <message>`, `::warning ...`, `::notice ...`. Each line identifies the offending fiche slug + rule.

## Local run against current data (2026-05-14)

```
Editorial rules summary — errors: 0, warnings: 2, notices: 0
EXIT: 0
```

The two warnings flag `PPL_MANDE_DU_SUD` and `PPL_KIRDI` — both lack `appellations.selfAppellation`. They stay advisory until they reach `confidence >= medium`.

## Failure-mode smoke test

A synthetic fiche with `confidence=high`, no autonym, `classification_status=contested`, and `sources=["only-one"]` produces:

```
exitCode: 1
findings: 3
 - error    autonym-required          PPL_VIOLATOR
 - error    sources-count             PPL_VIOLATOR
 - notice   doctrine-link-card-snapshot PPL_VIOLATOR
```

## Out of scope

- `DoctrineLinkCard` implementation itself — ETNI-28.
- Adding `classification_status` / `confidence` fields to existing fiches — ETNI-30 / data-cleanup tickets.

## Test plan

- [x] `npx vitest run scripts/ci/__tests__/checkEditorialRules.test.ts` — 32 tests pass.
- [x] `npx tsx scripts/ci/checkEditorialRules.ts` against current data — exits 0, surfaces 2 advisory warnings.
- [x] Synthetic failure scenario verifies exit code 1 + correct PR annotations.
- [x] `npm run type-check` clean.
