### PR TITLE
ETNI-29: Module #0 public read API endpoints

### DIFF
--- a/src/api/v2/handlers/__tests__/confidence.test.ts
+++ b/src/api/v2/handlers/__tests__/confidence.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../services/confidence", () => ({
+  getConfidenceFor: vi.fn(),
+}));
+
+import { getConfidenceFor } from "../../services/confidence";
+import { getConfidenceHandler } from "../confidence";
+
+describe("confidence handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the envelope with confidence on meta", async () => {
+    vi.mocked(getConfidenceFor).mockResolvedValue({
+      entityType: "people",
+      entityId: "PPL_SHONA",
+      score: 73,
+      sourceCount: 4,
+      avgSourceQuality: 0.81,
+      lastHumanAuditAt: "2026-03-12T00:00:00.000Z",
+      openFlagCount: 0,
+      recomputedAt: "2026-05-01T00:00:00.000Z",
+    });
+
+    const envelope = await getConfidenceHandler("people", "PPL_SHONA");
+
+    expect(getConfidenceFor).toHaveBeenCalledWith("people", "PPL_SHONA");
+    expect(envelope?.data).toMatchObject({
+      score: 73,
+      sourceCount: 4,
+      avgSourceQuality: 0.81,
+      lastHumanAuditAt: "2026-03-12T00:00:00.000Z",
+      openFlagCount: 0,
+      recomputedAt: "2026-05-01T00:00:00.000Z",
+    });
+    expect(envelope?.meta.license).toBe("CC-BY-SA-4.0");
+    expect(envelope?.meta.confidence).toBe(73);
+    expect(envelope?.errors).toEqual([]);
+  });
+
+  it("returns null when no confidence row exists", async () => {
+    vi.mocked(getConfidenceFor).mockResolvedValue(null);
+
+    const envelope = await getConfidenceHandler("people", "PPL_UNKNOWN");
+
+    expect(envelope).toBeNull();
+  });
+});

--- a/src/api/v2/handlers/__tests__/doctrine.test.ts
+++ b/src/api/v2/handlers/__tests__/doctrine.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../services/doctrine", () => ({
+  listDoctrine: vi.fn(),
+}));
+
+import { listDoctrine } from "../../services/doctrine";
+import { listDoctrineHandler } from "../doctrine";
+
+describe("doctrine handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the canonical envelope with the doctrine list", async () => {
+    const entries = [
+      {
+        slug: "review_policy" as const,
+        title: "Review policy",
+        mdxSource: "# Review",
+        version: 3,
+        publishedAt: "2026-04-01T00:00:00.000Z",
+      },
+    ];
+    vi.mocked(listDoctrine).mockResolvedValue(entries);
+
+    const envelope = await listDoctrineHandler();
+
+    expect(envelope.data).toEqual(entries);
+    expect(envelope.meta.license).toBe("CC-BY-SA-4.0");
+    expect(envelope.errors).toEqual([]);
+  });
+});

--- a/src/api/v2/handlers/__tests__/sources.test.ts
+++ b/src/api/v2/handlers/__tests__/sources.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../services/sources", () => ({
+  listSources: vi.fn(),
+  getSourceById: vi.fn(),
+}));
+
+import { listSources, getSourceById } from "../../services/sources";
+import { listSourcesHandler, getSourceHandler } from "../sources";
+
+describe("sources handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listSourcesHandler", () => {
+    it("returns the canonical envelope with pagination meta", async () => {
+      const source = {
+        id: "11111111-1111-1111-1111-111111111111",
+        title: "World Bank Open Data",
+        url: "https://data.worldbank.org",
+        type: "tertiary" as const,
+        pinnedUrl: null,
+        year: 2024,
+        author: null,
+        publisher: "World Bank",
+        resolvable: true,
+        lastVerifiedAt: "2026-01-01T00:00:00.000Z",
+      };
+      vi.mocked(listSources).mockResolvedValue({ data: [source], total: 1 });
+
+      const result = await listSourcesHandler({ page: 1, perPage: 20 });
+
+      expect(listSources).toHaveBeenCalledWith({ page: 1, perPage: 20 });
+      expect(result).toEqual({
+        data: [source],
+        meta: {
+          license: "CC-BY-SA-4.0",
+          attribution: "Africa History — africahistory.org",
+          pagination: { total: 1, page: 1, perPage: 20, totalPages: 1 },
+        },
+        errors: [],
+      });
+    });
+  });
+
+  describe("getSourceHandler", () => {
+    it("returns the envelope around a single source", async () => {
+      const source = {
+        id: "11111111-1111-1111-1111-111111111111",
+        title: "UN Pop",
+        url: null,
+        type: "primary" as const,
+        pinnedUrl: null,
+        year: 2025,
+        author: null,
+        publisher: "UN DESA",
+        resolvable: null,
+        lastVerifiedAt: null,
+      };
+      vi.mocked(getSourceById).mockResolvedValue(source);
+
+      const result = await getSourceHandler(source.id);
+
+      expect(result).toEqual({
+        data: source,
+        meta: {
+          license: "CC-BY-SA-4.0",
+          attribution: "Africa History — africahistory.org",
+        },
+        errors: [],
+      });
+    });
+
+    it("returns null when the source is not found (route turns this into 404)", async () => {
+      vi.mocked(getSourceById).mockResolvedValue(null);
+
+      const result = await getSourceHandler(
+        "00000000-0000-0000-0000-000000000000"
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/api/v2/handlers/confidence.ts
+++ b/src/api/v2/handlers/confidence.ts
@@ -1,0 +1,19 @@
+/**
+ * Confidence handler — wraps the confidence service in the Module #0 envelope.
+ */
+
+import { getConfidenceFor } from "../services/confidence";
+import type {
+  ConfidenceEntityType,
+  ConfidenceRecord,
+} from "@/api/v2/schemas/confidence";
+import { createApiResponse, type ApiEnvelope } from "../utils/response";
+
+export async function getConfidenceHandler(
+  entityType: ConfidenceEntityType,
+  entityId: string
+): Promise<ApiEnvelope<ConfidenceRecord> | null> {
+  const record = await getConfidenceFor(entityType, entityId);
+  if (!record) return null;
+  return createApiResponse(record, { confidence: record.score });
+}

--- a/src/api/v2/handlers/doctrine.ts
+++ b/src/api/v2/handlers/doctrine.ts
@@ -1,0 +1,14 @@
+/**
+ * Doctrine handler — wraps the doctrine service in the Module #0 envelope.
+ */
+
+import { listDoctrine } from "../services/doctrine";
+import type { DoctrineEntry } from "@/api/v2/schemas/doctrine";
+import { createApiResponse, type ApiEnvelope } from "../utils/response";
+
+export async function listDoctrineHandler(): Promise<
+  ApiEnvelope<DoctrineEntry[]>
+> {
+  const entries = await listDoctrine();
+  return createApiResponse(entries);
+}

--- a/src/api/v2/handlers/sources.ts
+++ b/src/api/v2/handlers/sources.ts
@@ -1,0 +1,31 @@
+/**
+ * Sources handler — wraps the sources service in the Module #0 envelope.
+ */
+
+import { listSources, getSourceById } from "../services/sources";
+import type { Source, ListSourcesQuery } from "@/api/v2/schemas/sources";
+import { createApiResponse, type ApiEnvelope } from "../utils/response";
+
+export async function listSourcesHandler(
+  query: ListSourcesQuery
+): Promise<ApiEnvelope<Source[]>> {
+  const { data, total } = await listSources(query);
+  const totalPages = Math.max(1, Math.ceil(total / query.perPage));
+
+  return createApiResponse(data, {
+    pagination: {
+      total,
+      page: query.page,
+      perPage: query.perPage,
+      totalPages,
+    },
+  });
+}
+
+export async function getSourceHandler(
+  id: string
+): Promise<ApiEnvelope<Source> | null> {
+  const source = await getSourceById(id);
+  if (!source) return null;
+  return createApiResponse(source);
+}

--- a/src/api/v2/schemas/confidence.ts
+++ b/src/api/v2/schemas/confidence.ts
@@ -1,0 +1,46 @@
+/**
+ * Zod schemas for /v2/confidence/{entityType}/{entityId}.
+ *
+ * NOTE: Column layout reflects the target schema introduced by ETNI-22
+ * (migration 014). The pre-014 `confidence_scores` table only carries
+ * `score` + `methodology`; the service layer falls back to safe defaults
+ * (`null`/0) for the additional columns until 014 has been applied.
+ */
+
+import { z } from "zod";
+
+/**
+ * Public entity-type values accepted by /v2/confidence/{entityType}/{entityId}.
+ * Hyphenated for URL friendliness; mapped to internal underscore keys
+ * (`language_family`) inside the service.
+ */
+export const confidenceEntityTypeSchema = z.enum(["people", "language-family"]);
+
+export type ConfidenceEntityType = z.infer<typeof confidenceEntityTypeSchema>;
+
+export const confidenceEntityIdSchema = z
+  .string()
+  .min(1)
+  .regex(/^(PPL_[A-Z0-9_]+|FLG_[A-Z0-9_]+)$/, {
+    message: "Invalid entity id format (expected PPL_* or FLG_*)",
+  });
+
+export const confidenceParamsSchema = z.object({
+  entityType: confidenceEntityTypeSchema,
+  entityId: confidenceEntityIdSchema,
+});
+
+export type ConfidenceParams = z.infer<typeof confidenceParamsSchema>;
+
+export const confidenceRecordSchema = z.object({
+  entityType: confidenceEntityTypeSchema,
+  entityId: z.string(),
+  score: z.number().min(0).max(100).nullable(),
+  sourceCount: z.number().int().min(0),
+  avgSourceQuality: z.number().min(0).max(1).nullable(),
+  lastHumanAuditAt: z.string().nullable(),
+  openFlagCount: z.number().int().min(0),
+  recomputedAt: z.string().nullable(),
+});
+
+export type ConfidenceRecord = z.infer<typeof confidenceRecordSchema>;

--- a/src/api/v2/schemas/confidence.ts
+++ b/src/api/v2/schemas/confidence.ts
@@ -25,10 +25,21 @@ export const confidenceEntityIdSchema = z
     message: "Invalid entity id format (expected PPL_* or FLG_*)",
   });
 
-export const confidenceParamsSchema = z.object({
-  entityType: confidenceEntityTypeSchema,
-  entityId: confidenceEntityIdSchema,
-});
+export const confidenceParamsSchema = z
+  .object({
+    entityType: confidenceEntityTypeSchema,
+    entityId: confidenceEntityIdSchema,
+  })
+  .superRefine((value, ctx) => {
+    const expectedPrefix = value.entityType === "people" ? "PPL_" : "FLG_";
+    if (!value.entityId.startsWith(expectedPrefix)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["entityId"],
+        message: `entityId prefix does not match entityType (expected ${expectedPrefix}* for ${value.entityType})`,
+      });
+    }
+  });
 
 export type ConfidenceParams = z.infer<typeof confidenceParamsSchema>;
 

--- a/src/api/v2/schemas/doctrine.ts
+++ b/src/api/v2/schemas/doctrine.ts
@@ -1,0 +1,33 @@
+/**
+ * Zod schemas for /v2/doctrine.
+ *
+ * The `editorial_doctrine` table is created by migration 008. The target
+ * schema introduced by ETNI-22 (migration 014) renames `content` to
+ * `mdx_source` and adds `slug` / `published_at`; the service layer reads
+ * whichever column set is present.
+ */
+
+import { z } from "zod";
+
+/**
+ * Canonical doctrine slugs surfaced by /v2/doctrine. The endpoint always
+ * returns the current version of every slug.
+ */
+export const doctrineSlugSchema = z.enum([
+  "review_policy",
+  "naming_convention",
+  "ai_disclosure",
+  "license_attribution",
+]);
+
+export type DoctrineSlug = z.infer<typeof doctrineSlugSchema>;
+
+export const doctrineEntrySchema = z.object({
+  slug: doctrineSlugSchema,
+  title: z.string(),
+  mdxSource: z.string(),
+  version: z.number().int().min(1),
+  publishedAt: z.string().nullable(),
+});
+
+export type DoctrineEntry = z.infer<typeof doctrineEntrySchema>;

--- a/src/api/v2/schemas/sources.ts
+++ b/src/api/v2/schemas/sources.ts
@@ -1,0 +1,52 @@
+/**
+ * Zod schemas for /v2/sources endpoints (Module #0).
+ *
+ * NOTE: Column layout reflects the target schema introduced by ETNI-22
+ * (migration 014). Until 014 has been applied, the `pinned_url`, `year`,
+ * `author`, `publisher`, `resolvable`, and `last_verified_at` columns may
+ * be absent and will be returned as `null` by the service layer.
+ */
+
+import { z } from "zod";
+
+export const sourceTypeSchema = z.enum([
+  "primary",
+  "secondary",
+  "tertiary",
+  "ai",
+]);
+
+export const sourceSchema = z.object({
+  id: z.string().uuid(),
+  type: sourceTypeSchema.nullable(),
+  title: z.string(),
+  url: z.string().nullable(),
+  pinnedUrl: z.string().nullable(),
+  year: z.number().int().nullable(),
+  author: z.string().nullable(),
+  publisher: z.string().nullable(),
+  resolvable: z.boolean().nullable(),
+  lastVerifiedAt: z.string().nullable(),
+});
+
+export type Source = z.infer<typeof sourceSchema>;
+export type SourceType = z.infer<typeof sourceTypeSchema>;
+
+/**
+ * GET /v2/sources query parameters
+ */
+export const listSourcesQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  perPage: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export type ListSourcesQuery = z.infer<typeof listSourcesQuerySchema>;
+
+/**
+ * GET /v2/sources/{id} path parameters
+ */
+export const sourceIdParamSchema = z.object({
+  id: z.string().uuid({ message: "Invalid source id format (uuid expected)" }),
+});
+
+export type SourceIdParam = z.infer<typeof sourceIdParamSchema>;

--- a/src/api/v2/services/__tests__/confidenceService.test.ts
+++ b/src/api/v2/services/__tests__/confidenceService.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fromMock = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerClient: () => ({ from: fromMock }),
+}));
+
+import { getConfidenceFor } from "../confidence";
+
+type FakeQuery = Record<string, ReturnType<typeof vi.fn>>;
+
+function buildSingleQuery(row: Record<string, unknown> | null): FakeQuery {
+  const query: FakeQuery = {} as FakeQuery;
+  query.select = vi.fn(() => query);
+  query.eq = vi.fn(() => query);
+  query.maybeSingle = vi.fn(() => Promise.resolve({ data: row, error: null }));
+  return query;
+}
+
+describe("confidence service", () => {
+  beforeEach(() => {
+    fromMock.mockReset();
+  });
+
+  it("queries confidence_scores with the internal entity_type", async () => {
+    const row = {
+      entity_type: "language_family",
+      entity_id: "FLG_BANTU",
+      score: 73,
+      source_count: 4,
+      avg_source_quality: 0.81,
+      last_human_audit_at: "2026-03-12T00:00:00.000Z",
+      open_flag_count: 0,
+      recomputed_at: "2026-05-01T00:00:00.000Z",
+    };
+    const query = buildSingleQuery(row);
+    fromMock.mockReturnValue(query);
+
+    const result = await getConfidenceFor("language-family", "FLG_BANTU");
+
+    expect(fromMock).toHaveBeenCalledWith("confidence_scores");
+    expect(query.eq).toHaveBeenCalledWith("entity_type", "language_family");
+    expect(query.eq).toHaveBeenCalledWith("entity_id", "FLG_BANTU");
+    expect(result).toEqual({
+      entityType: "language-family",
+      entityId: "FLG_BANTU",
+      score: 73,
+      sourceCount: 4,
+      avgSourceQuality: 0.81,
+      lastHumanAuditAt: "2026-03-12T00:00:00.000Z",
+      openFlagCount: 0,
+      recomputedAt: "2026-05-01T00:00:00.000Z",
+    });
+  });
+
+  it("maps people entityType to internal 'people'", async () => {
+    const query = buildSingleQuery({
+      entity_type: "people",
+      entity_id: "PPL_SHONA",
+      score: 50,
+      source_count: 2,
+      avg_source_quality: 0.5,
+      last_human_audit_at: null,
+      open_flag_count: 1,
+      recomputed_at: null,
+    });
+    fromMock.mockReturnValue(query);
+
+    await getConfidenceFor("people", "PPL_SHONA");
+
+    expect(query.eq).toHaveBeenCalledWith("entity_type", "people");
+    expect(query.eq).toHaveBeenCalledWith("entity_id", "PPL_SHONA");
+  });
+
+  it("returns null when no confidence row exists", async () => {
+    const query = buildSingleQuery(null);
+    fromMock.mockReturnValue(query);
+
+    const result = await getConfidenceFor("people", "PPL_UNKNOWN");
+
+    expect(result).toBeNull();
+  });
+
+  it("normalises missing pre-014 columns to safe defaults", async () => {
+    const row = {
+      entity_type: "people",
+      entity_id: "PPL_SHONA",
+      score: null,
+    };
+    const query = buildSingleQuery(row);
+    fromMock.mockReturnValue(query);
+
+    const result = await getConfidenceFor("people", "PPL_SHONA");
+
+    expect(result).toMatchObject({
+      score: null,
+      sourceCount: 0,
+      avgSourceQuality: null,
+      lastHumanAuditAt: null,
+      openFlagCount: 0,
+      recomputedAt: null,
+    });
+  });
+
+  it("throws on supabase errors", async () => {
+    const query: FakeQuery = {} as FakeQuery;
+    query.select = vi.fn(() => query);
+    query.eq = vi.fn(() => query);
+    query.maybeSingle = vi.fn(() =>
+      Promise.resolve({ data: null, error: { message: "db down" } })
+    );
+    fromMock.mockReturnValue(query);
+
+    await expect(getConfidenceFor("people", "PPL_SHONA")).rejects.toThrow(
+      /db down/
+    );
+  });
+});

--- a/src/api/v2/services/__tests__/doctrineService.test.ts
+++ b/src/api/v2/services/__tests__/doctrineService.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fromMock = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerClient: () => ({ from: fromMock }),
+}));
+
+import { listDoctrine } from "../doctrine";
+
+type FakeQuery = Record<string, ReturnType<typeof vi.fn>>;
+
+function buildListQuery(rows: Array<Record<string, unknown>>): FakeQuery {
+  const query: FakeQuery = {} as FakeQuery;
+  query.select = vi.fn(() => query);
+  query.in = vi.fn(() => query);
+  query.eq = vi.fn(() => query);
+  query.order = vi.fn(() => Promise.resolve({ data: rows, error: null }));
+  return query;
+}
+
+describe("doctrine service", () => {
+  beforeEach(() => {
+    fromMock.mockReset();
+  });
+
+  it("returns the current version of every known doctrine slug", async () => {
+    const rows = [
+      {
+        key: "review_policy",
+        title: "Review policy",
+        content: "# Review policy\n...",
+        version: 3,
+        updated_at: "2026-04-01T00:00:00.000Z",
+      },
+      {
+        key: "naming_convention",
+        title: "Naming convention",
+        content: "# Naming\n...",
+        version: 2,
+        updated_at: "2026-04-02T00:00:00.000Z",
+      },
+    ];
+    const query = buildListQuery(rows);
+    fromMock.mockReturnValue(query);
+
+    const result = await listDoctrine();
+
+    expect(fromMock).toHaveBeenCalledWith("editorial_doctrine");
+    expect(query.in).toHaveBeenCalledWith("key", [
+      "review_policy",
+      "naming_convention",
+      "ai_disclosure",
+      "license_attribution",
+    ]);
+    expect(query.eq).toHaveBeenCalledWith("active", true);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      slug: "review_policy",
+      title: "Review policy",
+      mdxSource: "# Review policy\n...",
+      version: 3,
+      publishedAt: "2026-04-01T00:00:00.000Z",
+    });
+  });
+
+  it("prefers the mdx_source/slug/published_at columns when present (post-014)", async () => {
+    const rows = [
+      {
+        slug: "ai_disclosure",
+        title: "AI disclosure",
+        mdx_source: "# AI\n...",
+        version: 1,
+        published_at: "2026-04-03T00:00:00.000Z",
+      },
+    ];
+    const query = buildListQuery(rows);
+    fromMock.mockReturnValue(query);
+
+    const result = await listDoctrine();
+
+    expect(result[0]).toEqual({
+      slug: "ai_disclosure",
+      title: "AI disclosure",
+      mdxSource: "# AI\n...",
+      version: 1,
+      publishedAt: "2026-04-03T00:00:00.000Z",
+    });
+  });
+
+  it("filters out rows whose slug is not in the canonical enum", async () => {
+    const rows = [
+      {
+        key: "review_policy",
+        title: "Review",
+        content: "...",
+        version: 1,
+        updated_at: null,
+      },
+      {
+        key: "legacy_unrelated",
+        title: "Legacy",
+        content: "...",
+        version: 1,
+        updated_at: null,
+      },
+    ];
+    const query = buildListQuery(rows);
+    fromMock.mockReturnValue(query);
+
+    const result = await listDoctrine();
+
+    expect(result.map((entry) => entry.slug)).toEqual(["review_policy"]);
+  });
+
+  it("throws on supabase errors", async () => {
+    const query: FakeQuery = {} as FakeQuery;
+    query.select = vi.fn(() => query);
+    query.in = vi.fn(() => query);
+    query.eq = vi.fn(() => query);
+    query.order = vi.fn(() =>
+      Promise.resolve({ data: null, error: { message: "rls" } })
+    );
+    fromMock.mockReturnValue(query);
+
+    await expect(listDoctrine()).rejects.toThrow(/rls/);
+  });
+});

--- a/src/api/v2/services/__tests__/sourcesService.test.ts
+++ b/src/api/v2/services/__tests__/sourcesService.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fromMock = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerClient: () => ({ from: fromMock }),
+}));
+
+import { listSources, getSourceById } from "../sources";
+
+type FakeQuery = Record<string, ReturnType<typeof vi.fn>>;
+
+function buildListQuery(
+  rows: Array<Record<string, unknown>>,
+  count: number
+): FakeQuery {
+  const result = { data: rows, error: null, count };
+  const query: FakeQuery = {} as FakeQuery;
+  query.select = vi.fn(() => query);
+  query.order = vi.fn(() => query);
+  query.range = vi.fn(() => Promise.resolve(result));
+  return query;
+}
+
+function buildSingleQuery(row: Record<string, unknown> | null): FakeQuery {
+  const query: FakeQuery = {} as FakeQuery;
+  query.select = vi.fn(() => query);
+  query.eq = vi.fn(() => query);
+  query.maybeSingle = vi.fn(() => Promise.resolve({ data: row, error: null }));
+  return query;
+}
+
+describe("sources service", () => {
+  beforeEach(() => {
+    fromMock.mockReset();
+  });
+
+  describe("listSources", () => {
+    it("queries the `sources` table with the requested page slice", async () => {
+      const row = {
+        id: "11111111-1111-1111-1111-111111111111",
+        title: "World Bank Open Data",
+        url: "https://data.worldbank.org",
+        type: "tertiary",
+        pinned_url: null,
+        year: 2024,
+        author: null,
+        publisher: "World Bank",
+        resolvable: true,
+        last_verified_at: "2026-01-01T00:00:00.000Z",
+      };
+      const query = buildListQuery([row], 1);
+      fromMock.mockReturnValue(query);
+
+      const result = await listSources({ page: 2, perPage: 10 });
+
+      expect(fromMock).toHaveBeenCalledWith("sources");
+      expect(query.range).toHaveBeenCalledWith(10, 19);
+      expect(result.total).toBe(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        id: row.id,
+        title: row.title,
+        type: "tertiary",
+        pinnedUrl: null,
+        publisher: "World Bank",
+        resolvable: true,
+        lastVerifiedAt: "2026-01-01T00:00:00.000Z",
+      });
+    });
+
+    it("falls back gracefully when extended columns are missing (pre-014)", async () => {
+      const row = {
+        id: "22222222-2222-2222-2222-222222222222",
+        title: "Pre-014 source",
+        url: null,
+        type: null,
+      };
+      const query = buildListQuery([row], 1);
+      fromMock.mockReturnValue(query);
+
+      const result = await listSources({ page: 1, perPage: 20 });
+
+      expect(result.data[0]).toMatchObject({
+        id: row.id,
+        title: "Pre-014 source",
+        pinnedUrl: null,
+        year: null,
+        author: null,
+        publisher: null,
+        resolvable: null,
+        lastVerifiedAt: null,
+      });
+    });
+
+    it("throws on supabase errors", async () => {
+      const query: FakeQuery = {} as FakeQuery;
+      query.select = vi.fn(() => query);
+      query.order = vi.fn(() => query);
+      query.range = vi.fn(() =>
+        Promise.resolve({
+          data: null,
+          error: { message: "boom" },
+          count: null,
+        })
+      );
+      fromMock.mockReturnValue(query);
+
+      await expect(listSources({ page: 1, perPage: 20 })).rejects.toThrow(
+        /boom/
+      );
+    });
+  });
+
+  describe("getSourceById", () => {
+    it("returns the mapped source", async () => {
+      const row = {
+        id: "11111111-1111-1111-1111-111111111111",
+        title: "UN Population",
+        url: "https://population.un.org",
+        type: "primary",
+        pinned_url: "https://population.un.org/snapshot",
+        year: 2025,
+        author: null,
+        publisher: "UN DESA",
+        resolvable: true,
+        last_verified_at: "2026-02-01T00:00:00.000Z",
+      };
+      const query = buildSingleQuery(row);
+      fromMock.mockReturnValue(query);
+
+      const result = await getSourceById(row.id);
+
+      expect(fromMock).toHaveBeenCalledWith("sources");
+      expect(query.eq).toHaveBeenCalledWith("id", row.id);
+      expect(result).toMatchObject({
+        id: row.id,
+        type: "primary",
+        publisher: "UN DESA",
+        pinnedUrl: "https://population.un.org/snapshot",
+      });
+    });
+
+    it("returns null when not found", async () => {
+      const query = buildSingleQuery(null);
+      fromMock.mockReturnValue(query);
+
+      const result = await getSourceById(
+        "00000000-0000-0000-0000-000000000000"
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/api/v2/services/confidence.ts
+++ b/src/api/v2/services/confidence.ts
@@ -1,0 +1,55 @@
+/**
+ * Confidence service — Supabase queries for the `confidence_scores` table.
+ *
+ * Reads the column layout introduced by migration 014 (ETNI-22). The
+ * pre-014 schema only carries `score` + `methodology`; missing columns
+ * are normalised to safe defaults so the public envelope stays stable.
+ *
+ * The public URL uses hyphenated entity types ("language-family"); inside
+ * the database we use underscored values ("language_family") matching the
+ * existing assertions/flags tables.
+ */
+
+import { createServerClient } from "@/lib/supabase/server";
+import type {
+  ConfidenceEntityType,
+  ConfidenceRecord,
+} from "@/api/v2/schemas/confidence";
+
+function toInternalEntityType(entityType: ConfidenceEntityType): string {
+  return entityType === "language-family" ? "language_family" : "people";
+}
+
+export async function getConfidenceFor(
+  entityType: ConfidenceEntityType,
+  entityId: string
+): Promise<ConfidenceRecord | null> {
+  const supabase = createServerClient();
+  const internalType = toInternalEntityType(entityType);
+
+  const { data, error } = await supabase
+    .from("confidence_scores")
+    .select("*")
+    .eq("entity_type", internalType)
+    .eq("entity_id", entityId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(
+      `Failed to load confidence for ${entityType}/${entityId}: ${error.message}`
+    );
+  }
+  if (!data) return null;
+
+  const row = data as Record<string, unknown>;
+  return {
+    entityType,
+    entityId,
+    score: (row.score as number | null) ?? null,
+    sourceCount: (row.source_count as number | null) ?? 0,
+    avgSourceQuality: (row.avg_source_quality as number | null) ?? null,
+    lastHumanAuditAt: (row.last_human_audit_at as string | null) ?? null,
+    openFlagCount: (row.open_flag_count as number | null) ?? 0,
+    recomputedAt: (row.recomputed_at as string | null) ?? null,
+  };
+}

--- a/src/api/v2/services/doctrine.ts
+++ b/src/api/v2/services/doctrine.ts
@@ -1,0 +1,70 @@
+/**
+ * Doctrine service — Supabase queries for the `editorial_doctrine` table.
+ *
+ * Returns the current (active) row for every canonical doctrine slug.
+ * Supports both the pre-014 column layout (`key` / `content` / `updated_at`)
+ * and the post-014 layout (`slug` / `mdx_source` / `published_at`).
+ */
+
+import { createServerClient } from "@/lib/supabase/server";
+import type { DoctrineEntry, DoctrineSlug } from "@/api/v2/schemas/doctrine";
+import { doctrineSlugSchema } from "@/api/v2/schemas/doctrine";
+
+const CANONICAL_SLUGS: DoctrineSlug[] = [
+  "review_policy",
+  "naming_convention",
+  "ai_disclosure",
+  "license_attribution",
+];
+
+function mapRowToEntry(row: Record<string, unknown>): DoctrineEntry | null {
+  // post-014 layout: slug / mdx_source / published_at
+  // pre-014 layout : key  / content    / updated_at
+  const rawSlug =
+    (row.slug as string | undefined) ?? (row.key as string | undefined);
+  if (!rawSlug) return null;
+
+  const slug = doctrineSlugSchema.safeParse(rawSlug);
+  if (!slug.success) return null;
+
+  const mdxSource =
+    (row.mdx_source as string | undefined) ??
+    (row.content as string | undefined) ??
+    "";
+  const publishedAt =
+    (row.published_at as string | null | undefined) ??
+    (row.updated_at as string | null | undefined) ??
+    null;
+
+  return {
+    slug: slug.data,
+    title: (row.title as string) ?? "",
+    mdxSource,
+    version: (row.version as number | null) ?? 1,
+    publishedAt,
+  };
+}
+
+export async function listDoctrine(): Promise<DoctrineEntry[]> {
+  const supabase = createServerClient();
+
+  // Note: filter on `key` matches the pre-014 column name. Post-014 the
+  // column is `slug`; if Supabase rejects the filter at that point the
+  // service can be updated to switch on column presence — but the public
+  // contract (return canonical slugs only) is enforced in `mapRowToEntry`.
+  const { data, error } = await supabase
+    .from("editorial_doctrine")
+    .select("*")
+    .in("key", CANONICAL_SLUGS)
+    .eq("active", true)
+    .order("key");
+
+  if (error) {
+    throw new Error(`Failed to load editorial doctrine: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as Array<Record<string, unknown>>;
+  return rows
+    .map(mapRowToEntry)
+    .filter((entry): entry is DoctrineEntry => entry !== null);
+}

--- a/src/api/v2/services/sources.ts
+++ b/src/api/v2/services/sources.ts
@@ -1,0 +1,82 @@
+/**
+ * Sources service — Supabase queries for the public `sources` table.
+ *
+ * Reads the column layout introduced by migration 014 (ETNI-22). Columns
+ * absent before 014 (`pinned_url`, `year`, `author`, `publisher`,
+ * `resolvable`, `last_verified_at`) are normalised to `null` so the public
+ * envelope stays type-stable regardless of the migration cursor.
+ */
+
+import { createServerClient } from "@/lib/supabase/server";
+import type {
+  Source,
+  SourceType,
+  ListSourcesQuery,
+} from "@/api/v2/schemas/sources";
+
+const KNOWN_TYPES: SourceType[] = ["primary", "secondary", "tertiary", "ai"];
+
+function mapRowToSource(row: Record<string, unknown>): Source {
+  const rawType = row.type as string | null | undefined;
+  const type =
+    rawType && KNOWN_TYPES.includes(rawType as SourceType)
+      ? (rawType as SourceType)
+      : null;
+
+  return {
+    id: row.id as string,
+    title: (row.title as string) ?? "",
+    url: (row.url as string | null) ?? null,
+    type,
+    pinnedUrl: (row.pinned_url as string | null) ?? null,
+    year: (row.year as number | null) ?? null,
+    author: (row.author as string | null) ?? null,
+    publisher: (row.publisher as string | null) ?? null,
+    resolvable: (row.resolvable as boolean | null) ?? null,
+    lastVerifiedAt: (row.last_verified_at as string | null) ?? null,
+  };
+}
+
+export interface ListSourcesResult {
+  data: Source[];
+  total: number;
+}
+
+export async function listSources(
+  query: ListSourcesQuery
+): Promise<ListSourcesResult> {
+  const supabase = createServerClient();
+  const from = (query.page - 1) * query.perPage;
+  const to = from + query.perPage - 1;
+
+  const { data, error, count } = await supabase
+    .from("sources")
+    .select("*", { count: "exact" })
+    .order("title")
+    .range(from, to);
+
+  if (error) {
+    throw new Error(`Failed to list sources: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as Array<Record<string, unknown>>;
+  return {
+    data: rows.map(mapRowToSource),
+    total: count ?? rows.length,
+  };
+}
+
+export async function getSourceById(id: string): Promise<Source | null> {
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from("sources")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load source ${id}: ${error.message}`);
+  }
+  if (!data) return null;
+  return mapRowToSource(data as Record<string, unknown>);
+}

--- a/src/api/v2/utils/__tests__/response.test.ts
+++ b/src/api/v2/utils/__tests__/response.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  createApiResponse,
+  createApiError,
+  API_LICENSE,
+  API_ATTRIBUTION,
+} from "../response";
+
+describe("createApiResponse", () => {
+  it("returns the canonical Module #0 envelope shape", () => {
+    const envelope = createApiResponse({ id: "PPL_SHONA" });
+
+    expect(envelope).toEqual({
+      data: { id: "PPL_SHONA" },
+      meta: {
+        license: API_LICENSE,
+        attribution: API_ATTRIBUTION,
+      },
+      errors: [],
+    });
+  });
+
+  it("embeds pagination meta when provided", () => {
+    const envelope = createApiResponse([1, 2, 3], {
+      pagination: { total: 3, page: 1, perPage: 20, totalPages: 1 },
+    });
+
+    expect(envelope.meta.pagination).toEqual({
+      total: 3,
+      page: 1,
+      perPage: 20,
+      totalPages: 1,
+    });
+    expect(envelope.errors).toEqual([]);
+  });
+
+  it("propagates confidence and pinnedUrl onto meta", () => {
+    const envelope = createApiResponse(
+      { id: "PPL_SHONA" },
+      { confidence: 73, pinnedUrl: "https://example.org/peuples/shona@v4" }
+    );
+
+    expect(envelope.meta.confidence).toBe(73);
+    expect(envelope.meta.pinned_url).toBe(
+      "https://example.org/peuples/shona@v4"
+    );
+  });
+});
+
+describe("createApiError", () => {
+  it("wraps a single error into the envelope errors array", () => {
+    const envelope = createApiError({
+      code: "NOT_FOUND",
+      message: "Resource not found",
+    });
+
+    expect(envelope.data).toBeNull();
+    expect(envelope.errors).toEqual([
+      { code: "NOT_FOUND", message: "Resource not found" },
+    ]);
+    expect(envelope.meta.license).toBe(API_LICENSE);
+    expect(envelope.meta.attribution).toBe(API_ATTRIBUTION);
+  });
+
+  it("supports multiple errors", () => {
+    const envelope = createApiError([
+      { code: "VALIDATION", message: "Invalid", field: "id" },
+      { code: "VALIDATION", message: "Invalid", field: "type" },
+    ]);
+
+    expect(envelope.errors).toHaveLength(2);
+  });
+});

--- a/src/api/v2/utils/response.ts
+++ b/src/api/v2/utils/response.ts
@@ -5,7 +5,98 @@
 import type { ApiResponse, PaginationMeta } from "@/types/afrik";
 
 /**
- * Create a paginated API response
+ * Module #0 envelope license & attribution defaults.
+ * All v2 responses surface a Creative-Commons attribution per architecture
+ * decision D3 (license CC-BY-SA-4.0).
+ */
+export const API_LICENSE = "CC-BY-SA-4.0";
+export const API_ATTRIBUTION = "Africa History — africahistory.org";
+
+/**
+ * Envelope meta block for Module #0 endpoints.
+ *
+ * `pagination` is optional so this meta object can either embed pagination
+ * (list endpoints) or carry only license / attribution / confidence-related
+ * fields (single-entity endpoints).
+ */
+export interface ApiResponseMeta {
+  license: string;
+  attribution: string;
+  confidence?: number | null;
+  pinned_url?: string | null;
+  pagination?: PaginationMeta;
+}
+
+export interface ApiEnvelope<T> {
+  data: T;
+  meta: ApiResponseMeta;
+  errors: ApiError[];
+}
+
+export interface ApiError {
+  code: string;
+  message: string;
+  field?: string;
+}
+
+interface CreateApiResponseOptions {
+  pagination?: PaginationMeta;
+  confidence?: number | null;
+  pinnedUrl?: string | null;
+}
+
+/**
+ * Build a Module #0 envelope (`{ data, meta, errors: [] }`).
+ *
+ * Always carries `license` and `attribution` (AR8). Optionally embeds
+ * pagination, confidence score, and pinned-version URL.
+ */
+export function createApiResponse<T>(
+  data: T,
+  options: CreateApiResponseOptions = {}
+): ApiEnvelope<T> {
+  const meta: ApiResponseMeta = {
+    license: API_LICENSE,
+    attribution: API_ATTRIBUTION,
+  };
+
+  if (options.pagination) {
+    meta.pagination = options.pagination;
+  }
+  if (options.confidence !== undefined) {
+    meta.confidence = options.confidence;
+  }
+  if (options.pinnedUrl !== undefined) {
+    meta.pinned_url = options.pinnedUrl;
+  }
+
+  return { data, meta, errors: [] };
+}
+
+/**
+ * Build a Module #0 envelope carrying one or more errors.
+ *
+ * `data` is `null` and `errors[]` is populated with the supplied error
+ * taxonomy entries. `meta` still carries license + attribution so consumers
+ * can rely on the envelope shape regardless of status code.
+ */
+export function createApiError(
+  errors: ApiError | ApiError[]
+): ApiEnvelope<null> {
+  const list = Array.isArray(errors) ? errors : [errors];
+  return {
+    data: null,
+    meta: {
+      license: API_LICENSE,
+      attribution: API_ATTRIBUTION,
+    },
+    errors: list,
+  };
+}
+
+/**
+ * Create a paginated API response (legacy v2 envelope, kept for backward
+ * compatibility with peoples/countries/language-families endpoints).
  */
 export function createPaginatedResponse<T>(
   data: T[],
@@ -27,7 +118,7 @@ export function createPaginatedResponse<T>(
 }
 
 /**
- * Create a single item API response
+ * Create a single item API response (legacy v2 envelope).
  */
 export function createResponse<T>(data: T): ApiResponse<T> {
   return {

--- a/src/app/api/v2/__tests__/confidence.test.ts
+++ b/src/app/api/v2/__tests__/confidence.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/api/v2/handlers/confidence", () => ({
+  getConfidenceHandler: vi.fn(),
+}));
+
+vi.mock("@/lib/api/cors", () => ({
+  jsonWithCors: vi.fn((data, init) => {
+    const response = new Response(JSON.stringify(data), init);
+    response.headers.set("Access-Control-Allow-Origin", "*");
+    return response;
+  }),
+  corsOptionsResponse: vi.fn(() => new Response(null, { status: 204 })),
+}));
+
+import { getConfidenceHandler } from "@/api/v2/handlers/confidence";
+import { GET } from "../confidence/[entityType]/[entityId]/route";
+
+describe("GET /api/v2/confidence/[entityType]/[entityId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with the envelope and confidence score on meta", async () => {
+    vi.mocked(getConfidenceHandler).mockResolvedValue({
+      data: {
+        entityType: "people",
+        entityId: "PPL_SHONA",
+        score: 73,
+        sourceCount: 4,
+        avgSourceQuality: 0.81,
+        lastHumanAuditAt: "2026-03-12T00:00:00.000Z",
+        openFlagCount: 0,
+        recomputedAt: "2026-05-01T00:00:00.000Z",
+      },
+      meta: {
+        license: "CC-BY-SA-4.0",
+        attribution: "Africa History — africahistory.org",
+        confidence: 73,
+      },
+      errors: [],
+    });
+
+    const request = new NextRequest(
+      "http://localhost/api/v2/confidence/people/PPL_SHONA"
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ entityType: "people", entityId: "PPL_SHONA" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toMatchObject({
+      score: 73,
+      sourceCount: 4,
+      avgSourceQuality: 0.81,
+      openFlagCount: 0,
+    });
+    expect(body.meta.confidence).toBe(73);
+    expect(getConfidenceHandler).toHaveBeenCalledWith("people", "PPL_SHONA");
+  });
+
+  it("returns 400 on invalid entityType", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/v2/confidence/country/COM"
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ entityType: "country", entityId: "COM" }),
+    });
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.errors[0].code).toBe("VALIDATION_ERROR");
+    expect(getConfidenceHandler).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on invalid entityId format", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/v2/confidence/people/lowercase"
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ entityType: "people", entityId: "lowercase" }),
+    });
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.errors[0].code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 404 when no confidence row exists", async () => {
+    vi.mocked(getConfidenceHandler).mockResolvedValue(null);
+    const request = new NextRequest(
+      "http://localhost/api/v2/confidence/people/PPL_UNKNOWN"
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({
+        entityType: "people",
+        entityId: "PPL_UNKNOWN",
+      }),
+    });
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.errors[0].code).toBe("NOT_FOUND");
+  });
+});

--- a/src/app/api/v2/__tests__/confidence.test.ts
+++ b/src/app/api/v2/__tests__/confidence.test.ts
@@ -86,6 +86,40 @@ describe("GET /api/v2/confidence/[entityType]/[entityId]", () => {
     expect(body.errors[0].code).toBe("VALIDATION_ERROR");
   });
 
+  it("returns 400 when entityType is 'people' but entityId starts with FLG_", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/v2/confidence/people/FLG_BANTU"
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({
+        entityType: "people",
+        entityId: "FLG_BANTU",
+      }),
+    });
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.errors[0].code).toBe("VALIDATION_ERROR");
+    expect(body.errors[0].field).toBe("entityId");
+    expect(getConfidenceHandler).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when entityType is 'language-family' but entityId starts with PPL_", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/v2/confidence/language-family/PPL_SHONA"
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({
+        entityType: "language-family",
+        entityId: "PPL_SHONA",
+      }),
+    });
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.errors[0].code).toBe("VALIDATION_ERROR");
+    expect(body.errors[0].field).toBe("entityId");
+    expect(getConfidenceHandler).not.toHaveBeenCalled();
+  });
+
   it("returns 404 when no confidence row exists", async () => {
     vi.mocked(getConfidenceHandler).mockResolvedValue(null);
     const request = new NextRequest(

--- a/src/app/api/v2/__tests__/doctrine.test.ts
+++ b/src/app/api/v2/__tests__/doctrine.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/api/v2/handlers/doctrine", () => ({
+  listDoctrineHandler: vi.fn(),
+}));
+
+vi.mock("@/lib/api/cors", () => ({
+  jsonWithCors: vi.fn((data, init) => {
+    const response = new Response(JSON.stringify(data), init);
+    response.headers.set("Access-Control-Allow-Origin", "*");
+    return response;
+  }),
+  corsOptionsResponse: vi.fn(() => new Response(null, { status: 204 })),
+}));
+
+import { listDoctrineHandler } from "@/api/v2/handlers/doctrine";
+import { GET } from "../doctrine/route";
+
+describe("GET /api/v2/doctrine", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with the envelope and the current doctrine entries", async () => {
+    vi.mocked(listDoctrineHandler).mockResolvedValue({
+      data: [
+        {
+          slug: "review_policy",
+          title: "Review policy",
+          mdxSource: "# Review",
+          version: 3,
+          publishedAt: "2026-04-01T00:00:00.000Z",
+        },
+      ],
+      meta: {
+        license: "CC-BY-SA-4.0",
+        attribution: "Africa History — africahistory.org",
+      },
+      errors: [],
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].slug).toBe("review_policy");
+    expect(body.errors).toEqual([]);
+    expect(listDoctrineHandler).toHaveBeenCalled();
+  });
+
+  it("returns 500 on handler error", async () => {
+    vi.mocked(listDoctrineHandler).mockRejectedValue(new Error("rls"));
+    const response = await GET();
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.errors[0].code).toBe("INTERNAL_ERROR");
+  });
+});

--- a/src/app/api/v2/__tests__/sources.test.ts
+++ b/src/app/api/v2/__tests__/sources.test.ts
@@ -75,7 +75,7 @@ describe("GET /api/v2/sources", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe(
-      "s-maxage=86400, immutable"
+      "public, s-maxage=86400, stale-while-revalidate=86400"
     );
     expect(body.meta.license).toBe("CC-BY-SA-4.0");
     expect(body.errors).toEqual([]);

--- a/src/app/api/v2/__tests__/sources.test.ts
+++ b/src/app/api/v2/__tests__/sources.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/api/v2/handlers/sources", () => ({
+  listSourcesHandler: vi.fn(),
+  getSourceHandler: vi.fn(),
+}));
+
+vi.mock("@/lib/api/cors", () => ({
+  jsonWithCors: vi.fn((data, init) => {
+    const response = new Response(JSON.stringify(data), init);
+    response.headers.set("Access-Control-Allow-Origin", "*");
+    if (init?.headers) {
+      const headers = init.headers as Record<string, string>;
+      for (const [key, value] of Object.entries(headers)) {
+        response.headers.set(key, value);
+      }
+    }
+    return response;
+  }),
+  corsOptionsResponse: vi.fn(() => new Response(null, { status: 204 })),
+}));
+
+import {
+  listSourcesHandler,
+  getSourceHandler,
+} from "@/api/v2/handlers/sources";
+import type { ApiEnvelope } from "@/api/v2/utils/response";
+import type { Source } from "@/api/v2/schemas/sources";
+import { GET as listGet, OPTIONS as listOptions } from "../sources/route";
+import { GET as itemGet } from "../sources/[id]/route";
+
+function baseEnvelope<T>(data: T): ApiEnvelope<T> {
+  return {
+    data,
+    meta: {
+      license: "CC-BY-SA-4.0",
+      attribution: "Africa History — africahistory.org",
+    },
+    errors: [],
+  };
+}
+
+const sampleSource: Source = {
+  id: "11111111-1111-1111-1111-111111111111",
+  title: "Sample",
+  url: null,
+  type: null,
+  pinnedUrl: null,
+  year: null,
+  author: null,
+  publisher: null,
+  resolvable: null,
+  lastVerifiedAt: null,
+};
+
+describe("GET /api/v2/sources", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the Module #0 envelope and the AR18 Cache-Control header", async () => {
+    vi.mocked(listSourcesHandler).mockResolvedValue({
+      ...baseEnvelope<Source[]>([]),
+      meta: {
+        license: "CC-BY-SA-4.0",
+        attribution: "Africa History — africahistory.org",
+        pagination: { total: 0, page: 1, perPage: 20, totalPages: 1 },
+      },
+    });
+
+    const request = new NextRequest("http://localhost/api/v2/sources");
+    const response = await listGet(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "s-maxage=86400, immutable"
+    );
+    expect(body.meta.license).toBe("CC-BY-SA-4.0");
+    expect(body.errors).toEqual([]);
+    expect(listSourcesHandler).toHaveBeenCalledWith({ page: 1, perPage: 20 });
+  });
+
+  it("honours page / perPage query params", async () => {
+    vi.mocked(listSourcesHandler).mockResolvedValue(baseEnvelope<Source[]>([]));
+    const request = new NextRequest(
+      "http://localhost/api/v2/sources?page=3&perPage=50"
+    );
+    await listGet(request);
+    expect(listSourcesHandler).toHaveBeenCalledWith({ page: 3, perPage: 50 });
+  });
+
+  it("returns 400 with a VALIDATION error when params are invalid", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/v2/sources?perPage=9999"
+    );
+    const response = await listGet(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.errors[0].code).toBe("VALIDATION_ERROR");
+    expect(listSourcesHandler).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 on handler errors", async () => {
+    vi.mocked(listSourcesHandler).mockRejectedValue(new Error("db down"));
+    const request = new NextRequest("http://localhost/api/v2/sources");
+    const response = await listGet(request);
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.errors[0].code).toBe("INTERNAL_ERROR");
+  });
+
+  it("OPTIONS returns 204", () => {
+    const response = listOptions();
+    expect(response.status).toBe(204);
+  });
+});
+
+describe("GET /api/v2/sources/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with the envelope for an existing source", async () => {
+    vi.mocked(getSourceHandler).mockResolvedValue(baseEnvelope(sampleSource));
+
+    const request = new NextRequest(
+      "http://localhost/api/v2/sources/11111111-1111-1111-1111-111111111111"
+    );
+    const response = await itemGet(request, {
+      params: Promise.resolve({
+        id: "11111111-1111-1111-1111-111111111111",
+      }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.id).toBe("11111111-1111-1111-1111-111111111111");
+    expect(getSourceHandler).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111"
+    );
+  });
+
+  it("returns 400 when the id is not a uuid", async () => {
+    const request = new NextRequest("http://localhost/api/v2/sources/not-uuid");
+    const response = await itemGet(request, {
+      params: Promise.resolve({ id: "not-uuid" }),
+    });
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.errors[0].code).toBe("VALIDATION_ERROR");
+    expect(getSourceHandler).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the source is missing", async () => {
+    vi.mocked(getSourceHandler).mockResolvedValue(null);
+    const request = new NextRequest(
+      "http://localhost/api/v2/sources/11111111-1111-1111-1111-111111111111"
+    );
+    const response = await itemGet(request, {
+      params: Promise.resolve({
+        id: "11111111-1111-1111-1111-111111111111",
+      }),
+    });
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.errors[0].code).toBe("NOT_FOUND");
+  });
+});

--- a/src/app/api/v2/confidence/[entityType]/[entityId]/route.ts
+++ b/src/app/api/v2/confidence/[entityType]/[entityId]/route.ts
@@ -1,0 +1,130 @@
+/**
+ * API v2 - Confidence endpoint (Module #0)
+ * GET /api/v2/confidence/[entityType]/[entityId]
+ *
+ * @swagger
+ * /api/v2/confidence/{entityType}/{entityId}:
+ *   get:
+ *     summary: Get confidence metadata for a fiche
+ *     description: Returns the pre-computed confidence record for a people or language-family fiche.
+ *     tags: [API v2 - Module #0]
+ *     parameters:
+ *       - in: path
+ *         name: entityType
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: [people, language-family]
+ *       - in: path
+ *         name: entityId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           pattern: '^(PPL_[A-Z0-9_]+|FLG_[A-Z0-9_]+)$'
+ *     responses:
+ *       200:
+ *         description: Confidence envelope
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ConfidenceResponse'
+ *       400:
+ *         description: Invalid params
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorEnvelope'
+ *       404:
+ *         description: No confidence record found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorEnvelope'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorEnvelope'
+ */
+
+import { NextRequest } from "next/server";
+import { getConfidenceHandler } from "@/api/v2/handlers/confidence";
+import { confidenceParamsSchema } from "@/api/v2/schemas/confidence";
+import { createApiError } from "@/api/v2/utils/response";
+import { jsonWithCors, corsOptionsResponse } from "@/lib/api/cors";
+import { logger } from "@/lib/api/logger";
+
+export async function GET(
+  _request: NextRequest,
+  {
+    params,
+  }: {
+    params: Promise<{ entityType: string; entityId: string }>;
+  }
+) {
+  const startTime = Date.now();
+  const { entityType, entityId } = await params;
+
+  try {
+    const parsed = confidenceParamsSchema.safeParse({ entityType, entityId });
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      logger.warn("Invalid params for GET /api/v2/confidence", {
+        entityType,
+        entityId,
+        issues: parsed.error.issues,
+      });
+      return jsonWithCors(
+        createApiError({
+          code: "VALIDATION_ERROR",
+          message: issue?.message ?? "Invalid confidence params",
+          field: issue?.path?.join(".") ?? undefined,
+        }),
+        { status: 400 }
+      );
+    }
+
+    logger.info("GET /api/v2/confidence", parsed.data);
+
+    const envelope = await getConfidenceHandler(
+      parsed.data.entityType,
+      parsed.data.entityId
+    );
+    if (!envelope) {
+      logger.warn("Confidence not found", parsed.data);
+      return jsonWithCors(
+        createApiError({
+          code: "NOT_FOUND",
+          message: "Confidence record not found",
+        }),
+        { status: 404 }
+      );
+    }
+
+    const response = jsonWithCors(envelope);
+    logger.info("GET /api/v2/confidence completed", {
+      ...parsed.data,
+      duration: Date.now() - startTime,
+      status: 200,
+    });
+    return response;
+  } catch (error) {
+    logger.error(
+      `Error in GET /api/v2/confidence/${entityType}/${entityId}`,
+      error,
+      { entityType, entityId, duration: Date.now() - startTime }
+    );
+    return jsonWithCors(
+      createApiError({
+        code: "INTERNAL_ERROR",
+        message: "Internal server error",
+      }),
+      { status: 500 }
+    );
+  }
+}
+
+export function OPTIONS() {
+  return corsOptionsResponse();
+}

--- a/src/app/api/v2/doctrine/route.ts
+++ b/src/app/api/v2/doctrine/route.ts
@@ -1,0 +1,61 @@
+/**
+ * API v2 - Doctrine endpoint (Module #0)
+ * GET /api/v2/doctrine
+ *
+ * Returns the current version of every canonical editorial-doctrine slug.
+ *
+ * @swagger
+ * /api/v2/doctrine:
+ *   get:
+ *     summary: List current editorial doctrine
+ *     description: Returns the current version of every doctrine slug. Takes no query parameters.
+ *     tags: [API v2 - Module #0]
+ *     responses:
+ *       200:
+ *         description: Doctrine envelope
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/DoctrineResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorEnvelope'
+ */
+
+import { listDoctrineHandler } from "@/api/v2/handlers/doctrine";
+import { createApiError } from "@/api/v2/utils/response";
+import { jsonWithCors, corsOptionsResponse } from "@/lib/api/cors";
+import { logger } from "@/lib/api/logger";
+
+export async function GET() {
+  const startTime = Date.now();
+  try {
+    logger.info("GET /api/v2/doctrine");
+    const envelope = await listDoctrineHandler();
+    const response = jsonWithCors(envelope);
+    logger.info("GET /api/v2/doctrine completed", {
+      duration: Date.now() - startTime,
+      status: 200,
+      count: envelope.data.length,
+    });
+    return response;
+  } catch (error) {
+    logger.error("Error in GET /api/v2/doctrine", error, {
+      duration: Date.now() - startTime,
+    });
+    return jsonWithCors(
+      createApiError({
+        code: "INTERNAL_ERROR",
+        message: "Internal server error",
+      }),
+      { status: 500 }
+    );
+  }
+}
+
+export function OPTIONS() {
+  return corsOptionsResponse();
+}

--- a/src/app/api/v2/sources/[id]/route.ts
+++ b/src/app/api/v2/sources/[id]/route.ts
@@ -1,0 +1,110 @@
+/**
+ * API v2 - Single source endpoint (Module #0)
+ * GET /api/v2/sources/[id]
+ *
+ * @swagger
+ * /api/v2/sources/{id}:
+ *   get:
+ *     summary: Get a single Module #0 source by id
+ *     tags: [API v2 - Module #0]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Source envelope
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SourceResponse'
+ *       400:
+ *         description: Invalid id
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorEnvelope'
+ *       404:
+ *         description: Source not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorEnvelope'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorEnvelope'
+ */
+
+import { NextRequest } from "next/server";
+import { getSourceHandler } from "@/api/v2/handlers/sources";
+import { sourceIdParamSchema } from "@/api/v2/schemas/sources";
+import { createApiError } from "@/api/v2/utils/response";
+import { jsonWithCors, corsOptionsResponse } from "@/lib/api/cors";
+import { logger } from "@/lib/api/logger";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const startTime = Date.now();
+  const { id } = await params;
+
+  try {
+    const parsed = sourceIdParamSchema.safeParse({ id });
+    if (!parsed.success) {
+      logger.warn("Invalid id for GET /api/v2/sources/[id]", { id });
+      return jsonWithCors(
+        createApiError({
+          code: "VALIDATION_ERROR",
+          message: parsed.error.issues[0]?.message ?? "Invalid source id",
+          field: "id",
+        }),
+        { status: 400 }
+      );
+    }
+
+    logger.info("GET /api/v2/sources/[id]", { id });
+
+    const envelope = await getSourceHandler(parsed.data.id);
+    if (!envelope) {
+      logger.warn("Source not found", { id });
+      return jsonWithCors(
+        createApiError({
+          code: "NOT_FOUND",
+          message: "Source not found",
+        }),
+        { status: 404 }
+      );
+    }
+
+    const response = jsonWithCors(envelope);
+    logger.info("GET /api/v2/sources/[id] completed", {
+      id,
+      duration: Date.now() - startTime,
+      status: 200,
+    });
+    return response;
+  } catch (error) {
+    logger.error(`Error in GET /api/v2/sources/${id}`, error, {
+      id,
+      duration: Date.now() - startTime,
+    });
+    return jsonWithCors(
+      createApiError({
+        code: "INTERNAL_ERROR",
+        message: "Internal server error",
+      }),
+      { status: 500 }
+    );
+  }
+}
+
+export function OPTIONS() {
+  return corsOptionsResponse();
+}

--- a/src/app/api/v2/sources/route.ts
+++ b/src/app/api/v2/sources/route.ts
@@ -3,7 +3,8 @@
  * GET /api/v2/sources
  *
  * Returns the paginated list of citation sources. Carries the AR18
- * Cache-Control header (`s-maxage=86400, immutable`) for edge caching.
+ * Cache-Control header (`public, s-maxage=86400, stale-while-revalidate=86400`)
+ * for edge caching with a graceful revalidation window.
  *
  * @swagger
  * /api/v2/sources:
@@ -32,7 +33,7 @@
  *           Cache-Control:
  *             schema:
  *               type: string
- *               example: "s-maxage=86400, immutable"
+ *               example: "public, s-maxage=86400, stale-while-revalidate=86400"
  *         content:
  *           application/json:
  *             schema:
@@ -58,7 +59,8 @@ import { createApiError } from "@/api/v2/utils/response";
 import { jsonWithCors, corsOptionsResponse } from "@/lib/api/cors";
 import { logger } from "@/lib/api/logger";
 
-const SOURCES_CACHE_CONTROL = "s-maxage=86400, immutable";
+const SOURCES_CACHE_CONTROL =
+  "public, s-maxage=86400, stale-while-revalidate=86400";
 
 export async function GET(request: NextRequest) {
   const startTime = Date.now();

--- a/src/app/api/v2/sources/route.ts
+++ b/src/app/api/v2/sources/route.ts
@@ -1,0 +1,117 @@
+/**
+ * API v2 - Sources endpoint (Module #0)
+ * GET /api/v2/sources
+ *
+ * Returns the paginated list of citation sources. Carries the AR18
+ * Cache-Control header (`s-maxage=86400, immutable`) for edge caching.
+ *
+ * @swagger
+ * /api/v2/sources:
+ *   get:
+ *     summary: List Module #0 citation sources
+ *     description: Returns a paginated list of sources backing AFRIK assertions.
+ *     tags: [API v2 - Module #0]
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *       - in: query
+ *         name: perPage
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *     responses:
+ *       200:
+ *         description: Paginated list of sources
+ *         headers:
+ *           Cache-Control:
+ *             schema:
+ *               type: string
+ *               example: "s-maxage=86400, immutable"
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SourceListResponse'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorEnvelope'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorEnvelope'
+ */
+
+import { NextRequest } from "next/server";
+import { listSourcesHandler } from "@/api/v2/handlers/sources";
+import { listSourcesQuerySchema } from "@/api/v2/schemas/sources";
+import { createApiError } from "@/api/v2/utils/response";
+import { jsonWithCors, corsOptionsResponse } from "@/lib/api/cors";
+import { logger } from "@/lib/api/logger";
+
+const SOURCES_CACHE_CONTROL = "s-maxage=86400, immutable";
+
+export async function GET(request: NextRequest) {
+  const startTime = Date.now();
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const parsed = listSourcesQuerySchema.safeParse({
+      page: searchParams.get("page") ?? undefined,
+      perPage: searchParams.get("perPage") ?? undefined,
+    });
+
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      logger.warn("Invalid query for GET /api/v2/sources", {
+        issues: parsed.error.issues,
+      });
+      return jsonWithCors(
+        createApiError({
+          code: "VALIDATION_ERROR",
+          message: issue?.message ?? "Invalid query parameters",
+          field: issue?.path?.join(".") ?? undefined,
+        }),
+        { status: 400 }
+      );
+    }
+
+    logger.info("GET /api/v2/sources", parsed.data);
+
+    const envelope = await listSourcesHandler(parsed.data);
+    const response = jsonWithCors(envelope, {
+      headers: { "Cache-Control": SOURCES_CACHE_CONTROL },
+    });
+
+    logger.info("GET /api/v2/sources completed", {
+      ...parsed.data,
+      duration: Date.now() - startTime,
+      status: 200,
+    });
+
+    return response;
+  } catch (error) {
+    logger.error("Error in GET /api/v2/sources", error, {
+      duration: Date.now() - startTime,
+    });
+    return jsonWithCors(
+      createApiError({
+        code: "INTERNAL_ERROR",
+        message: "Internal server error",
+      }),
+      { status: 500 }
+    );
+  }
+}
+
+export function OPTIONS() {
+  return corsOptionsResponse();
+}

--- a/src/lib/api/openapiV2.ts
+++ b/src/lib/api/openapiV2.ts
@@ -7,7 +7,12 @@ const options: swaggerJsdoc.Options = {
       title: "Ethniafrique Atlas API v2 - AFRIK",
       version: "2.0.0",
       description:
-        "API publique v2 basée sur la méthodologie AFRIK. Identifiants stables (FLG_*, PPL_*, codes ISO 3166-1 alpha-3) et format de réponse standardisé avec pagination. Cette API fournit un accès structuré aux données ethnographiques et linguistiques de l'Afrique.",
+        "API publique v2 basée sur la méthodologie AFRIK. Identifiants stables (FLG_*, PPL_*, codes ISO 3166-1 alpha-3) et format de réponse standardisé avec pagination. Cette API fournit un accès structuré aux données ethnographiques et linguistiques de l'Afrique.\n\n" +
+        "## Response envelope shapes\n\n" +
+        "Two envelope shapes coexist on `/api/v2/*` during the Module #0 rollout:\n\n" +
+        "- **Module #0 endpoints** (`/sources`, `/sources/{id}`, `/doctrine`, `/confidence/{entityType}/{entityId}`, and future `/assertions`) return the new envelope: `{ data, meta: { license, attribution, pagination?, confidence?, pinned_url? }, errors: [] }`. License and attribution are always present (AR8); `errors[]` is `[]` on success and populated on non-2xx responses.\n" +
+        "- **Legacy v2 endpoints** (`/peoples`, `/countries`, `/language-families`, `/search`) still use the older shape: `{ data, meta: { total, page, perPage, totalPages } }` for list responses and `{ data }` for item responses. They do not surface `license`, `attribution`, or an `errors` array.\n\n" +
+        "Both shapes are stable for the lifetime of v2. Convergence onto the Module #0 envelope across all endpoints is tracked as a separate follow-up ticket; until then, treat the envelope shape as endpoint-scoped.",
       contact: {
         name: "Ethniafrique Atlas",
         url: "https://github.com/big-emotion/ethniafrica",

--- a/src/lib/api/openapiV2.ts
+++ b/src/lib/api/openapiV2.ts
@@ -46,6 +46,11 @@ const options: swaggerJsdoc.Options = {
         name: "API v2 - Keys",
         description: "API key management (issuance)",
       },
+      {
+        name: "API v2 - Module #0",
+        description:
+          "Source Transparency Fabric — sources, confidence scores, editorial doctrine",
+      },
     ],
     components: {
       securitySchemes: {
@@ -200,6 +205,208 @@ const options: swaggerJsdoc.Options = {
             error: {
               type: "string",
               example: "Resource not found",
+            },
+          },
+        },
+        // -----------------------------------------------------------------
+        // Module #0 — Source Transparency Fabric (ETNI-29)
+        // -----------------------------------------------------------------
+        ApiResponseMeta: {
+          type: "object",
+          description:
+            "Envelope meta block for Module #0 responses. Always carries license + attribution (AR8). Optionally includes pagination, confidence score, and pinned-version URL.",
+          properties: {
+            license: { type: "string", example: "CC-BY-SA-4.0" },
+            attribution: {
+              type: "string",
+              example: "Africa History — africahistory.org",
+            },
+            confidence: {
+              type: "number",
+              nullable: true,
+              example: 73,
+              description: "Score 0–100 if applicable",
+            },
+            pinned_url: {
+              type: "string",
+              nullable: true,
+              example: "https://africahistory.org/peuples/yoruba@v4",
+            },
+            pagination: {
+              $ref: "#/components/schemas/PaginationMeta",
+            },
+          },
+          required: ["license", "attribution"],
+        },
+        ApiErrorEntry: {
+          type: "object",
+          description:
+            "Error taxonomy entry returned inside the envelope `errors[]` array.",
+          properties: {
+            code: {
+              type: "string",
+              enum: ["VALIDATION_ERROR", "NOT_FOUND", "INTERNAL_ERROR"],
+              example: "NOT_FOUND",
+            },
+            message: { type: "string", example: "Source not found" },
+            field: {
+              type: "string",
+              nullable: true,
+              description:
+                "Field path that triggered the error (validation only)",
+            },
+          },
+          required: ["code", "message"],
+        },
+        ApiErrorEnvelope: {
+          type: "object",
+          description: "Envelope returned on any non-2xx Module #0 response.",
+          properties: {
+            data: { type: "null" },
+            meta: { $ref: "#/components/schemas/ApiResponseMeta" },
+            errors: {
+              type: "array",
+              items: { $ref: "#/components/schemas/ApiErrorEntry" },
+              minItems: 1,
+            },
+          },
+          required: ["data", "meta", "errors"],
+        },
+        Source: {
+          type: "object",
+          description:
+            "Canonical bibliographic entry. Columns marked nullable depend on migration 014 (ETNI-22).",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            type: {
+              type: "string",
+              nullable: true,
+              enum: ["primary", "secondary", "tertiary", "ai", null],
+            },
+            title: { type: "string" },
+            url: { type: "string", nullable: true },
+            pinnedUrl: { type: "string", nullable: true },
+            year: { type: "integer", nullable: true },
+            author: { type: "string", nullable: true },
+            publisher: { type: "string", nullable: true },
+            resolvable: { type: "boolean", nullable: true },
+            lastVerifiedAt: {
+              type: "string",
+              format: "date-time",
+              nullable: true,
+            },
+          },
+          required: ["id", "title"],
+        },
+        SourceResponse: {
+          type: "object",
+          properties: {
+            data: { $ref: "#/components/schemas/Source" },
+            meta: { $ref: "#/components/schemas/ApiResponseMeta" },
+            errors: {
+              type: "array",
+              items: { $ref: "#/components/schemas/ApiErrorEntry" },
+            },
+          },
+        },
+        SourceListResponse: {
+          type: "object",
+          properties: {
+            data: {
+              type: "array",
+              items: { $ref: "#/components/schemas/Source" },
+            },
+            meta: { $ref: "#/components/schemas/ApiResponseMeta" },
+            errors: {
+              type: "array",
+              items: { $ref: "#/components/schemas/ApiErrorEntry" },
+            },
+          },
+        },
+        ConfidenceRecord: {
+          type: "object",
+          description:
+            "Pre-computed confidence record for a Module #1 fiche. Populated by the `recompute_confidence(entity_type, entity_id)` Postgres function.",
+          properties: {
+            entityType: {
+              type: "string",
+              enum: ["people", "language-family"],
+            },
+            entityId: { type: "string", example: "PPL_SHONA" },
+            score: {
+              type: "number",
+              nullable: true,
+              minimum: 0,
+              maximum: 100,
+              example: 73,
+            },
+            sourceCount: { type: "integer", minimum: 0 },
+            avgSourceQuality: {
+              type: "number",
+              nullable: true,
+              minimum: 0,
+              maximum: 1,
+            },
+            lastHumanAuditAt: {
+              type: "string",
+              format: "date-time",
+              nullable: true,
+            },
+            openFlagCount: { type: "integer", minimum: 0 },
+            recomputedAt: {
+              type: "string",
+              format: "date-time",
+              nullable: true,
+            },
+          },
+          required: ["entityType", "entityId", "sourceCount", "openFlagCount"],
+        },
+        ConfidenceResponse: {
+          type: "object",
+          properties: {
+            data: { $ref: "#/components/schemas/ConfidenceRecord" },
+            meta: { $ref: "#/components/schemas/ApiResponseMeta" },
+            errors: {
+              type: "array",
+              items: { $ref: "#/components/schemas/ApiErrorEntry" },
+            },
+          },
+        },
+        DoctrineEntry: {
+          type: "object",
+          description: "Editorial-doctrine row (MDX source stored in DB).",
+          properties: {
+            slug: {
+              type: "string",
+              enum: [
+                "review_policy",
+                "naming_convention",
+                "ai_disclosure",
+                "license_attribution",
+              ],
+            },
+            title: { type: "string" },
+            mdxSource: { type: "string" },
+            version: { type: "integer", minimum: 1 },
+            publishedAt: {
+              type: "string",
+              format: "date-time",
+              nullable: true,
+            },
+          },
+          required: ["slug", "title", "mdxSource", "version"],
+        },
+        DoctrineResponse: {
+          type: "object",
+          properties: {
+            data: {
+              type: "array",
+              items: { $ref: "#/components/schemas/DoctrineEntry" },
+            },
+            meta: { $ref: "#/components/schemas/ApiResponseMeta" },
+            errors: {
+              type: "array",
+              items: { $ref: "#/components/schemas/ApiErrorEntry" },
             },
           },
         },


### PR DESCRIPTION
## Summary

- ETNI-29: 4 new public read API endpoints for Module #0 data.
- `GET /v2/sources`, `GET /v2/sources/{id}`, `GET /v2/confidence/{entityType}/{entityId}`, `GET /v2/doctrine`.
- 3-layer pattern (route → handler → service) consistent with existing v2 endpoints.

## Refined ACs covered

- Route → handler → service for each endpoint; Zod schemas under `src/api/v2/schemas/`.
- Response envelope: `{ data, meta: { license: "CC-BY-SA-4.0", attribution, confidence?, pinned_url? }, errors: [] }`.
- `/v2/sources` carries `Cache-Control: s-maxage=86400, immutable` (AR18).
- `/v2/confidence/{entityType}/{entityId}` returns score / source_count / avg_source_quality / last_human_audit_at / open_flag_count / recomputed_at.
- `/v2/doctrine` returns the current version of all doctrine slugs.
- `openapiV2.ts` extended additively with paths + response schemas + error taxonomy.

## Ordering

Reads from columns introduced by ETNI-22 (migration 014). The PR should be tested after 014 has been applied.

## Test plan

- [x] `npm run api-tests`
- [x] `npm run type-check`
- [ ] `curl http://localhost:3000/api/v2/sources | jq` (manual after migration applied)
