### PR TITLE
fix: correct TOAST_REMOVE_DELAY typo (1,000,000 -> 5,000)

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -3,7 +3,7 @@ import * as React from "react";
 import type { ToastActionElement, ToastProps } from "@/components/ui/toast";
 
 const TOAST_LIMIT = 1;
-const TOAST_REMOVE_DELAY = 1000000;
+const TOAST_REMOVE_DELAY = 5000;
 
 type ToasterToast = ToastProps & {
   id: string;


### PR DESCRIPTION
Fixed typo in use-toast.ts: TOAST_REMOVE_DELAY was 1000000 (~16 min), changed to 5000 (5 sec).

Closes #97