### PR TITLE
fix(db): resolve duplicate 015_ migration prefix

### DIFF
--- a/supabase/migrations/015a_editorial_doctrine_rls_lockdown.sql
+++ b/supabase/migrations/015a_editorial_doctrine_rls_lockdown.sql
@@ -1,5 +1,5 @@
 -- =============================================================================
--- Migration: 015_editorial_doctrine_rls_lockdown.sql
+-- Migration: 015a_editorial_doctrine_rls_lockdown.sql
 -- Story: ETNI-30 — Editorial doctrine RLS lockdown
 -- =============================================================================
 --


### PR DESCRIPTION
## Summary

Unblocks PR #126 by resolving one of the pre-merge blockers called out in its description: the duplicate `015_` migration prefix on `recette`.

- Rename `015_editorial_doctrine_rls_lockdown.sql` → `015a_editorial_doctrine_rls_lockdown.sql`
- Update the file's internal `-- Migration: ...` header to match the new filename
- Keeps RLS lockdown ordered before the `016_editorial_doctrine_seed.sql` it protects
- Matches the existing `007/007a_user_roles.sql` precedent in this tree

## Why `015a_` and not `016` / `017a`

Renumbering to `016+` would push the doctrine seed and `017_afrik_rls` out by one, which is more churn (and would also break `016`'s logical "follows the lockdown" relationship). `015a_` is the minimum-change variant that keeps the existing later numbers stable.

## Test plan

- [ ] `ls supabase/migrations/` shows no two files starting with the same numeric prefix
- [ ] Re-apply on staging Supabase project; assert idempotency
- [ ] Confirm `editorial_doctrine` RLS policies exist before seed runs (`015a` before `016`)

## Related

- PR #126 — top of "Pre-merge blockers" list