### PR TITLE
fix(ci): gate Playwright e2e workflow on TEST_SUPABASE_* secret presence

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,28 +13,8 @@ permissions:
 # Persona thresholds (Amina 10 s, Ngozi 30 s) are SLOs — they assume the
 # CPU + network throttle encoded in playwright.config.ts.
 jobs:
-  preflight:
-    name: Preflight (check test Supabase secrets)
-    runs-on: ubuntu-latest
-    outputs:
-      have_secrets: ${{ steps.check.outputs.have_secrets }}
-    steps:
-      - id: check
-        env:
-          URL: ${{ secrets.TEST_SUPABASE_URL }}
-          ANON: ${{ secrets.TEST_SUPABASE_ANON_KEY }}
-        run: |
-          if [ -n "$URL" ] && [ -n "$ANON" ]; then
-            echo "have_secrets=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "have_secrets=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::TEST_SUPABASE_URL / TEST_SUPABASE_ANON_KEY not set — Playwright E2E job will be skipped. Configure these repo secrets to enable."
-          fi
-
   e2e:
     name: Playwright
-    needs: preflight
-    if: ${{ needs.preflight.outputs.have_secrets == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -60,18 +40,35 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      # Skip cleanly on forks / Dependabot PRs that cannot access the test
+      # Supabase secrets. When the secrets are set (i.e. on PRs from the same
+      # repo) the gate is enforced — no continue-on-error masks failures.
+      - name: Check required secrets are present
+        id: secrets
+        run: |
+          if [ -n "${{ secrets.TEST_SUPABASE_URL }}" ] && [ -n "${{ secrets.TEST_SUPABASE_ANON_KEY }}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Playwright E2E — TEST_SUPABASE_URL / TEST_SUPABASE_ANON_KEY secrets not available (fork, Dependabot PR, or unconfigured repo). Configure these repo secrets to enable."
+          fi
+
       - name: Install Playwright browsers
+        if: steps.secrets.outputs.present == 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Build app
+        if: steps.secrets.outputs.present == 'true'
         run: npm run build
 
       - name: Start app
+        if: steps.secrets.outputs.present == 'true'
         run: npx next start -p 3000 &
         env:
           PORT: 3000
 
       - name: Wait for app
+        if: steps.secrets.outputs.present == 'true'
         run: |
           for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
             if curl -fsS http://localhost:3000/fr > /dev/null; then
@@ -82,13 +79,14 @@ jobs:
           echo "App did not become ready"; exit 1
 
       - name: Run Playwright
+        if: steps.secrets.outputs.present == 'true'
         run: npx playwright test
         env:
           BASE_URL: http://localhost:3000
           SKIP_WEB_SERVER: "1"
 
       - name: Upload report
-        if: always()
+        if: always() && steps.secrets.outputs.present == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report


### PR DESCRIPTION
Closes #125.

## Summary

- Gate `.github/workflows/e2e.yml` build/start/wait/run/upload steps on `TEST_SUPABASE_*` secret presence (Path B from the issue).
- Mirrors the pattern already used in `.github/workflows/lighthouse.yml` — a single `Check required secrets are present` step writes `present=true|false` to `$GITHUB_OUTPUT`, then dependent steps gate on `steps.secrets.outputs.present == 'true'`. Emits a `::notice::` when secrets are absent so the skip is visible.
- `Upload report` keeps its `always() &&` guard so it still uploads on test failure when secrets ARE configured.

## Why

The Playwright workflow has been failing red on every push because the three secrets (`TEST_SUPABASE_URL`, `TEST_SUPABASE_ANON_KEY`, `TEST_SUPABASE_SERVICE_ROLE_KEY`) are not provisioned. This Path B gate stops the red noise on every PR without requiring secret provisioning today. Path A (provision a dedicated test Supabase project) remains an open follow-up.

## Test plan

- [ ] CI workflow runs on this PR and the Playwright job cleanly skips with a `::notice::` (no red ❌).
- [ ] Once `TEST_SUPABASE_*` secrets are provisioned, the gate flips to `true` and the suite runs end-to-end with the persona SLOs intact (Amina 10s, Ngozi 30s — `playwright.config.ts`).
- [ ] No regression on the `lighthouse.yml` workflow (untouched).