### PR TITLE
fix(audit): add FR28-strict warning and align CLAUDE.md doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Schema: `supabase/migrations/006_afrik_schema.sql`
 
 1. **Always use strict models** from `public/modele-*.json` — never skip, rename, or add sections
 2. **Never invent data** — every claim must be backed by a verifiable primary source (see [Source Tier Policy](#source-tier-policy))
-3. **Demographics**: 2025 reference year, populations must sum to exactly 100% per country
+3. **Demographics**: 2025 reference year. Populations must sum to 100% per country. During the transition, the validator (`scripts/validateAfrikData.ts` FR28) hard-gates at **[95, 105]%** and emits a soft warning **FR28-strict** for any fiche outside **[99, 101]%**. The doctrinal target is [99, 101]%; the hard gate will be tightened to match once every fiche lands inside it. New or updated fiches must aim for the strict band. See `docs/adr/0001-fr28-demographic-tolerance.md`.
 4. **Colonial terms**: Keep but explain why problematic; provide auto-appellations (endonyms)
 5. **Consistency**: Source JSON demographics must match database records
 

--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -153,7 +153,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
   - **Tier 3 (forbidden)**: Wikipedia articles themselves, blogs, social media, AI-generated content, secondary aggregators without their own primary sources.
   - Each `sources` entry must record `tier: 1` or `tier: 2`. Tier-2 entries must record the Wikipedia language versions cross-checked in `notes`.
 - **Database table names** (canonical, per migration `006_afrik_schema.sql`): `afrik_language_families`, `afrik_languages`, `afrik_peoples`, `afrik_countries`, `afrik_people_countries`. The French names (`afrik_familles_linguistiques`, `afrik_langues`, `afrik_peuples`, `afrik_pays`) do NOT exist in the DB — using them causes runtime failures.
-- **Demographics**: 2025 reference year; populations must sum to **exactly 100%** per country.
+- **Demographics**: 2025 reference year; populations must sum to 100% per country. Validator `scripts/validateAfrikData.ts` FR28 hard-gates at **[95, 105]%** and emits a soft warning **FR28-strict** for any fiche outside **[99, 101]%** (the doctrinal target). The hard gate will be tightened to [99, 101]% once every fiche fits inside it. New / updated fiches must aim for [99, 101]%. Rationale: `docs/adr/0001-fr28-demographic-tolerance.md`.
 - **Colonial terms**: keep but explain why problematic; always provide auto-appellations (endonyms).
 - **Consistency**: TXT demographics MUST match database records.
 

--- a/docs/adr/0001-fr28-demographic-tolerance.md
+++ b/docs/adr/0001-fr28-demographic-tolerance.md
@@ -1,0 +1,61 @@
+# ADR-0001: FR28 demographic tolerance band — transition plan
+
+- **Status**: Accepted
+- **Date**: 2026-05-14
+- **Issue**: [#131](https://github.com/big-emotion/ethniafrica/issues/131)
+
+## Context
+
+The AFRIK data doctrine in `CLAUDE.md` and `_bmad-output/project-context.md`
+stated that, for every country fiche, the sum of
+`content.demographics.peoples[].percentageInCountry` must equal **exactly 100%**.
+
+The validator (`scripts/validateAfrikData.ts`, check **FR28**) does not enforce
+that doctrine. It gates at the wider band **[95, 105]%**, originally chosen as
+a soft landing while issue #105 re-sourced 30 countries' demographic splits.
+
+As of 2026-05-14, **9 countries** sum to between 95.2% and 99.7% — they pass
+FR28 but violate the doctrine: LBR, COD, SEN, MOZ, KEN, MWI, ETH, GAB, MLI, GHA.
+
+Tightening FR28 to [99, 101]% immediately would fail validation for all 9 and
+block the build. Leaving the doctrine at "exactly 100%" while the validator
+accepts [95, 105]% keeps the two artifacts out of sync and makes the rule
+unenforceable in practice.
+
+## Decision
+
+Adopt a two-band transition plan:
+
+1. **Hard gate — FR28** stays at **[95, 105]%** (errors, fails validation).
+   No tightening until every fiche fits the strict band.
+2. **Soft warning — FR28-strict** added at **[99, 101]%** (warnings only,
+   never fails the build). Surfaces fiches that pass FR28 but miss the
+   doctrinal target.
+3. **Doctrine wording** in `CLAUDE.md` and `_bmad-output/project-context.md`
+   updated to describe the two bands and the transition target, replacing the
+   unenforced "exactly 100%" phrasing.
+4. **Exit path**: once the FR28-strict warning list is empty for a full
+   validation run, FR28's hard gate will be tightened to [99, 101]% and the
+   strict warning retired. Tracked in follow-up to issue #131.
+
+## Consequences
+
+**Positive**
+
+- Doctrine and validator agree — contributors can trust either one.
+- The 9 out-of-band countries surface as warnings on every run, creating
+  steady pressure to close the gap without blocking the build today.
+- KISS: one new function (`checkPopulationSumsStrict`), one new entry in the
+  validator's check registry, no data files touched.
+
+**Negative**
+
+- Two bands instead of one until the migration completes — slightly more
+  surface area to explain to new contributors.
+- Soft warnings can be ignored. Mitigation: the ADR pins the exit criterion,
+  and follow-up tickets track each non-conforming country.
+
+**Out of scope**
+
+- Re-sourcing the 9 country demographic splits (issues #129 and #130).
+- Changes to `dataset/source/afrik/` data files.

--- a/scripts/validateAfrikData.ts
+++ b/scripts/validateAfrikData.ts
@@ -869,6 +869,12 @@ export function checkPplDuplicates(datasetRoot: string): ValidationResult {
 
 /**
  * FR28 – For each pays JSON, the sum of peoples[].percentageInCountry must be [95, 105].
+ *
+ * Tolerance bands (transition plan — see docs/adr/0001-fr28-demographic-tolerance.md):
+ *   - Hard gate (this function):     [95, 105] — errors, fails validation.
+ *   - Strict warning (checkPopulationSumsStrict): [99, 101] — warnings only.
+ * The strict warning is the doctrinal target; the hard gate will be tightened
+ * once all country fiches land inside [99, 101].
  */
 export function checkPopulationSums(datasetRoot: string): ValidationResult {
   const errors: string[] = [];
@@ -913,6 +919,61 @@ export function checkPopulationSums(datasetRoot: string): ValidationResult {
   }
 
   return { ok: errors.length === 0, errors, warnings };
+}
+
+/**
+ * FR28-strict – Soft warning for the doctrinal target band [99, 101].
+ *
+ * Emits a warning per pays JSON whose peoples[].percentageInCountry sum falls
+ * outside [99, 101] but inside the FR28 hard gate [95, 105]. Does not fail
+ * validation — informational only. Once every fiche sits inside [99, 101],
+ * FR28's hard gate can be tightened to match and this check retired.
+ */
+export function checkPopulationSumsStrict(
+  datasetRoot: string
+): ValidationResult {
+  const warnings: string[] = [];
+
+  const paysDir = path.join(datasetRoot, "pays");
+  if (!fs.existsSync(paysDir)) {
+    return { ok: true, errors: [], warnings: [] };
+  }
+
+  const jsonFiles = fs.readdirSync(paysDir).filter((f) => f.endsWith(".json"));
+  for (const file of jsonFiles) {
+    const fullPath = path.join(paysDir, file);
+    let data: {
+      id?: string;
+      content?: {
+        demographics?: {
+          peoples?: Array<{ percentageInCountry?: number }>;
+        };
+      };
+    };
+    try {
+      data = JSON.parse(fs.readFileSync(fullPath, "utf-8"));
+    } catch {
+      // FR28 already reports parse failures; stay silent here to avoid duplicates.
+      continue;
+    }
+
+    const peoples = data?.content?.demographics?.peoples;
+    if (!peoples || peoples.length === 0) continue;
+
+    const sum = peoples.reduce(
+      (acc, p) => acc + (p.percentageInCountry ?? 0),
+      0
+    );
+    if (sum < 99 || sum > 101) {
+      const countryId = data.id ?? path.basename(file, ".json");
+      warnings.push(
+        `${countryId}: population percentages sum to ${sum.toFixed(2)}% (strict target 99–101%)`
+      );
+    }
+  }
+
+  // Always ok — this check is informational and never fails the build.
+  return { ok: true, errors: [], warnings };
 }
 
 /**
@@ -1156,6 +1217,13 @@ async function main() {
   newChecks.push({
     name: "FR28 Population sums",
     result: checkPopulationSums(datasetRoot),
+    soft: true,
+  });
+
+  console.log("FR28-strict – Population sums (target 99–101%)...");
+  newChecks.push({
+    name: "FR28-strict Population sums (target 99–101%)",
+    result: checkPopulationSumsStrict(datasetRoot),
     soft: true,
   });
 


### PR DESCRIPTION
Closes #131.

## Summary

- Add `FR28-strict` soft check at `[99, 101]%` that emits per-fiche warnings without failing the build.
- Keep FR28 hard gate at `[95, 105]%` so the 9 countries flagged in the issue are not regressed today.
- Update `CLAUDE.md` and `_bmad-output/project-context.md` to replace "must sum to exactly 100%" with transition wording (hard gate / strict warning / target band).
- Record the decision in `docs/adr/0001-fr28-demographic-tolerance.md` (Context / Decision / Consequences / Status: Accepted, 2026-05-14).

## Why

CLAUDE.md said "exactly 100%" but the validator gated at `[95, 105]%`. After PR #128, 9 countries pass FR28 but violate the strict doctrine. Per the issue's recommendation, this PR implements **Option A as a transition plan** — keep the hard gate today, add a soft warning at the target band, tighten when the warning list is empty.

## Validator output

```
✅ FR28-strict Population sums (target 99–101%)
   ⚠️  COD: 96.00%
   ⚠️  DJI: 98.00%
   ⚠️  DZA: 98.60%
   ⚠️  KEN: 98.60%
   ⚠️  LBR: 95.20%
   ⚠️  MAR: 96.20%
   ⚠️  MOZ: 98.00%
   ⚠️  SEN: 97.40%
   ⚠️  TUN: 98.00%
```

The exact offender list differs slightly from the one in the issue body (dataset shifted after PR #128 / #105) — mechanism is correct, current state is what the validator now reports.

## Test plan

- [ ] `npx tsx scripts/validateAfrikData.ts` exits 0 (verified locally).
- [ ] `npx vitest run scripts/__tests__/validateAfrikData.test.ts` — 23/23 pass.
- [ ] `npm run type-check` clean.
- [ ] Exit criterion documented in the ADR: when the FR28-strict warning list is empty, tighten FR28 hard gate to `[99, 101]%` and retire the strict check.