### PR TITLE
feat(audit): add FR32 drift detection script and soft validator gate

### DIFF
--- a/scripts/checkPopulationPercentageDrift.ts
+++ b/scripts/checkPopulationPercentageDrift.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env tsx
+/**
+ * Issue #130 — Detect and (optionally) fix internal drift between
+ * `population` and `percentageInCountry` on entries under
+ * `content.demographics.peoples` in `dataset/source/afrik/pays/*.json`.
+ *
+ * Per PR #128, `percentageInCountry` is the trust anchor. When both fields
+ * are present and the drift exceeds 2 percentage points, KISS option 2 says
+ * the `population` integer must be removed so the two fields cannot desync.
+ *
+ * Usage:
+ *   tsx scripts/checkPopulationPercentageDrift.ts          # report only
+ *   tsx scripts/checkPopulationPercentageDrift.ts --fix    # delete drifting population fields
+ *
+ * Idempotent: re-running after --fix yields zero offenders.
+ *
+ * Country totals come from `public/pays_demographie.csv` (UN/UNFPA 2025).
+ * ZAF is excluded: issue #129 owns the ZAF demographics rebuild.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { parse } from "csv-parse/sync";
+
+const DRIFT_THRESHOLD_PP = 2;
+const EXCLUDED_COUNTRIES = new Set(["ZAF"]); // owned by issue #129
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const PAYS_DIR = path.join(REPO_ROOT, "dataset/source/afrik/pays");
+const PAYS_CSV = path.join(REPO_ROOT, "public/pays_demographie.csv");
+
+interface Offender {
+  country: string;
+  people: string;
+  population: number;
+  impliedPct: number;
+  statedPct: number;
+  driftPp: number;
+}
+
+/** Load country totals (id_pays → population_totale_2025). */
+function loadCountryTotals(): Map<string, number> {
+  const raw = fs.readFileSync(PAYS_CSV, "utf-8");
+  const rows = parse(raw, {
+    columns: true,
+    skip_empty_lines: true,
+    trim: true,
+  }) as Array<{ id_pays?: string; population_totale_2025?: string }>;
+  const totals = new Map<string, number>();
+  for (const row of rows) {
+    if (!row.id_pays || !row.population_totale_2025) continue;
+    const total = Number(row.population_totale_2025);
+    if (!Number.isFinite(total) || total <= 0) continue;
+    totals.set(row.id_pays, total);
+  }
+  return totals;
+}
+
+/** Scan all pays JSON and return the list of drifting entries. */
+export function findDriftOffenders(
+  countryTotals: Map<string, number>,
+  options: { includeExcluded?: boolean } = {}
+): Offender[] {
+  const offenders: Offender[] = [];
+  const files = fs.readdirSync(PAYS_DIR).filter((f) => f.endsWith(".json"));
+
+  for (const file of files) {
+    const id = path.basename(file, ".json");
+    if (!options.includeExcluded && EXCLUDED_COUNTRIES.has(id)) continue;
+
+    const total = countryTotals.get(id);
+    if (!total) continue;
+
+    const fullPath = path.join(PAYS_DIR, file);
+    const data = JSON.parse(fs.readFileSync(fullPath, "utf-8"));
+    const peoples = data?.content?.demographics?.peoples ?? [];
+
+    for (const entry of peoples) {
+      if (typeof entry?.population !== "number") continue;
+      if (typeof entry?.percentageInCountry !== "number") continue;
+      const implied = (entry.population / total) * 100;
+      const drift = Math.abs(implied - entry.percentageInCountry);
+      if (drift > DRIFT_THRESHOLD_PP) {
+        offenders.push({
+          country: id,
+          people: entry.name ?? "(unnamed)",
+          population: entry.population,
+          impliedPct: Number(implied.toFixed(2)),
+          statedPct: entry.percentageInCountry,
+          driftPp: Number(drift.toFixed(2)),
+        });
+      }
+    }
+  }
+
+  return offenders;
+}
+
+/**
+ * Remove the `population` key from every drifting entry in-place using a
+ * surgical line-level edit. `JSON.parse + JSON.stringify` would reformat
+ * compact arrays (e.g. `["a", "b"]` becomes multi-line), so we keep the file
+ * intact and only excise matching `"population": <n>,` lines.
+ *
+ * Strategy:
+ *   1. Parse JSON to enumerate offending entries (which we already have).
+ *   2. Walk the raw text, locate the demographics.peoples array block, and
+ *      drop the `"population": ...` line from each entry that matches by
+ *      `name` and whose population value matches the offender.
+ *
+ * If the population line is the last key in the entry, we also fix the
+ * trailing comma on the previous line. (None of the current offenders hit
+ * this branch — population is always followed by other keys — but we handle
+ * it for robustness.)
+ */
+function applyFix(offenders: Offender[]): number {
+  // Group offenders by country: name → population value(s) to delete.
+  const byCountry = new Map<string, Map<string, Set<number>>>();
+  for (const o of offenders) {
+    if (!byCountry.has(o.country)) byCountry.set(o.country, new Map());
+    const peopleMap = byCountry.get(o.country)!;
+    if (!peopleMap.has(o.people)) peopleMap.set(o.people, new Set());
+    peopleMap.get(o.people)!.add(o.population);
+  }
+
+  let deletedCount = 0;
+
+  for (const [country, peopleMap] of byCountry) {
+    const fullPath = path.join(PAYS_DIR, `${country}.json`);
+    const original = fs.readFileSync(fullPath, "utf-8");
+    const lines = original.split("\n");
+
+    // Track the most recent "name" value seen inside an entry, so when we
+    // hit a "population" line we know whether it belongs to a flagged people.
+    let currentName: string | null = null;
+    const linesToDelete = new Set<number>();
+
+    const nameRe = /^\s*"name":\s*"([^"]*)"/;
+    const populationRe = /^(\s*)"population":\s*(\d+)(,?)\s*$/;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const nameMatch = line.match(nameRe);
+      if (nameMatch) {
+        currentName = nameMatch[1];
+        continue;
+      }
+      const popMatch = line.match(populationRe);
+      if (!popMatch || currentName === null) continue;
+      const popValue = Number(popMatch[2]);
+      const flagged = peopleMap.get(currentName);
+      if (!flagged || !flagged.has(popValue)) continue;
+      linesToDelete.add(i);
+      deletedCount += 1;
+    }
+
+    if (linesToDelete.size === 0) continue;
+
+    const newLines: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      if (linesToDelete.has(i)) continue;
+      newLines.push(lines[i]);
+    }
+    fs.writeFileSync(fullPath, newLines.join("\n"));
+  }
+
+  return deletedCount;
+}
+
+function formatTable(offenders: Offender[]): string {
+  if (offenders.length === 0) return "  (none)";
+  const header = [
+    "Country",
+    "People",
+    "Population",
+    "Implied%",
+    "Stated%",
+    "Drift(pp)",
+  ];
+  const rows = offenders.map((o) => [
+    o.country,
+    o.people,
+    String(o.population),
+    o.impliedPct.toFixed(2),
+    o.statedPct.toFixed(2),
+    o.driftPp.toFixed(2),
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => r[i].length))
+  );
+  const fmt = (r: string[]) =>
+    "  " + r.map((c, i) => c.padEnd(widths[i])).join("  ");
+  return [
+    fmt(header),
+    fmt(widths.map((w) => "-".repeat(w))),
+    ...rows.map(fmt),
+  ].join("\n");
+}
+
+function main() {
+  const fix = process.argv.includes("--fix");
+  const totals = loadCountryTotals();
+
+  // Report-only scan (excluding ZAF, the issue-#129 territory).
+  const offenders = findDriftOffenders(totals);
+  // Separate ZAF view for transparency.
+  const zafView = findDriftOffenders(totals, { includeExcluded: true }).filter(
+    (o) => EXCLUDED_COUNTRIES.has(o.country)
+  );
+
+  console.log(
+    `Drift threshold: > ${DRIFT_THRESHOLD_PP} pp. Reference totals: public/pays_demographie.csv (UN/UNFPA 2025).`
+  );
+  console.log(
+    `\nFound ${offenders.length} drifting entr${offenders.length === 1 ? "y" : "ies"} across ${
+      new Set(offenders.map((o) => o.country)).size
+    } countries (ZAF excluded — owned by #129):\n`
+  );
+  console.log(formatTable(offenders));
+
+  if (zafView.length > 0) {
+    console.log(
+      `\nZAF entries (informational only, not touched here — #129 owns ZAF):\n`
+    );
+    console.log(formatTable(zafView));
+  }
+
+  if (fix) {
+    const deleted = applyFix(offenders);
+    console.log(
+      `\n--fix applied: deleted the \`population\` field from ${deleted} entr${
+        deleted === 1 ? "y" : "ies"
+      }.`
+    );
+    const after = findDriftOffenders(totals);
+    if (after.length === 0) {
+      console.log("Post-fix scan: 0 drifting entries remaining. ✅");
+      process.exit(0);
+    } else {
+      console.log(`Post-fix scan: ${after.length} entries still drifting. ❌`);
+      process.exit(1);
+    }
+  }
+
+  process.exit(offenders.length === 0 ? 0 : 1);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/validateAfrikData.ts
+++ b/scripts/validateAfrikData.ts
@@ -1045,6 +1045,109 @@ export async function checkSourceUrls(
 }
 
 /**
+ * FR32 – population/percentageInCountry consistency.
+ *
+ * For each entry under `content.demographics.peoples` in `pays/*.json`,
+ * if BOTH `population` and `percentageInCountry` are present, the implied
+ * percentage `(population / country_total) × 100` must agree with the stated
+ * `percentageInCountry` within 2 percentage points.
+ *
+ * Registered as `soft: true` (warning, not failure) for now: the country
+ * page transformer (`src/lib/countryDataTransformer.ts`) reads
+ * `p.population` directly to compute per-row counts and `totalPopulation`.
+ * Deleting drifting `population` values today collapses those values to 0
+ * on the country page. Flip to a hard gate once the transformer is updated
+ * to derive population from `percentageInCountry × country total`.
+ *
+ * Country totals are loaded from `public/pays_demographie.csv`
+ * (UN/UNFPA 2025). If a country has no row in that CSV, the check is skipped
+ * for that country with a warning (no invented data). Issue #129 owns ZAF.
+ *
+ * Per issue #130 KISS option 2, the `population` field is the optional one:
+ * when both are present and drift > 2 pp, delete `population`. See
+ * `scripts/checkPopulationPercentageDrift.ts`.
+ */
+const FR32_DRIFT_PP = 2;
+const FR32_ZAF_SOFT = new Set(["ZAF"]); // owned by issue #129
+
+export function checkPopulationPercentageDrift(
+  datasetRoot: string,
+  paysCsvPath: string
+): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const paysDir = path.join(datasetRoot, "pays");
+  if (!fs.existsSync(paysDir)) {
+    return { ok: true, errors, warnings };
+  }
+
+  // Load country totals from CSV (id_pays → population_totale_2025).
+  const totals = new Map<string, number>();
+  if (fs.existsSync(paysCsvPath)) {
+    const rows = loadCSV(paysCsvPath);
+    for (const row of rows) {
+      const id = row.id_pays;
+      const pop = Number(row.population_totale_2025);
+      if (id && Number.isFinite(pop) && pop > 0) totals.set(id, pop);
+    }
+  } else {
+    warnings.push(
+      `FR32: country totals CSV not found at ${paysCsvPath} — check skipped`
+    );
+    return { ok: true, errors, warnings };
+  }
+
+  const files = fs.readdirSync(paysDir).filter((f) => f.endsWith(".json"));
+  for (const file of files) {
+    const id = path.basename(file, ".json");
+    const total = totals.get(id);
+    if (!total) {
+      warnings.push(
+        `FR32 ${id}: no row in pays_demographie.csv — drift check skipped (no invented total)`
+      );
+      continue;
+    }
+
+    let data: {
+      content?: {
+        demographics?: {
+          peoples?: Array<{
+            name?: string;
+            population?: number;
+            percentageInCountry?: number;
+          }>;
+        };
+      };
+    };
+    try {
+      data = JSON.parse(fs.readFileSync(path.join(paysDir, file), "utf-8"));
+    } catch {
+      warnings.push(`FR32 ${file}: could not parse JSON`);
+      continue;
+    }
+
+    const peoples = data?.content?.demographics?.peoples ?? [];
+    for (const entry of peoples) {
+      if (typeof entry?.population !== "number") continue;
+      if (typeof entry?.percentageInCountry !== "number") continue;
+      const implied = (entry.population / total) * 100;
+      const drift = Math.abs(implied - entry.percentageInCountry);
+      if (drift > FR32_DRIFT_PP) {
+        const msg = `FR32 ${id}/${entry.name ?? "(unnamed)"}: population ${entry.population} implies ${implied.toFixed(2)}% but percentageInCountry is ${entry.percentageInCountry}% (drift ${drift.toFixed(2)} pp > ${FR32_DRIFT_PP} pp threshold) — drop the population field (see scripts/checkPopulationPercentageDrift.ts)`;
+        if (FR32_ZAF_SOFT.has(id)) {
+          warnings.push(msg + " [soft: owned by issue #129]");
+        } else {
+          errors.push(msg);
+        }
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+/**
  * Orphan fiches – PPL files whose parent folder doesn't exist as a FLG JSON.
  * (Complements FR26 from the PPL perspective.)
  */
@@ -1163,6 +1266,16 @@ async function main() {
   newChecks.push({
     name: "FR29 ISO validity",
     result: checkIsoValidity(datasetRoot),
+  });
+
+  console.log("FR32 – population/percentageInCountry drift...");
+  newChecks.push({
+    name: "FR32 population/percentageInCountry drift",
+    result: checkPopulationPercentageDrift(
+      datasetRoot,
+      path.join(PUBLIC_ROOT, "pays_demographie.csv")
+    ),
+    soft: true,
   });
 
   console.log("Orphan fiches...");


### PR DESCRIPTION
## Summary

Adds detection-only infrastructure for the `population` vs. `percentageInCountry` drift problem described in issue #130. Data cleanup deferred.

### What's in
- **`scripts/checkPopulationPercentageDrift.ts`** — scans `dataset/source/afrik/pays/*.json` against UN/UNFPA 2025 country totals in `public/pays_demographie.csv`, reports entries whose implied % diverges from stated `percentageInCountry` by more than 2pp. Supports `--fix`.
- **FR32 in `scripts/validateAfrikData.ts`** — registered as **soft** (warning, not failure) so the gate surfaces drift in CI logs without breaking the build.

### What's deferred to a follow-up PR
- **The 44 data deletions.** The country page transformer (`src/lib/countryDataTransformer.ts`) reads `p.population` directly to compute per-row counts and `totalPopulation`. Deleting drifting `population` values today would collapse those numbers to 0 on the country page. A follow-up PR should pair the data cleanup with a transformer migration that derives population from `percentageInCountry × country total`, then flip FR32 from soft to hard.

### CI
- `validate` (Data Integrity Gate) — runs the new soft FR32 check, emits warnings, exits 0.

Closes: partial — #130. Remaining cleanup tracked for follow-up.