### PR TITLE
test(ferry): point actions at @main for live testing

### DIFF
--- a/.github/workflows/ferry-dev.yml
+++ b/.github/workflows/ferry-dev.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate event envelope
-        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@main
         with:
           payload: ${{ toJson(github.event.client_payload) }}
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run Developer agent
         id: run-developer
-        uses: big-emotion/ferry/.github/actions/ferry-run-developer@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-run-developer@main
         with:
           payload: ${{ toJson(github.event.client_payload) }}
           jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
@@ -85,7 +85,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Emit audit line
-        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@main
         with:
           ticket: ${{ github.event.client_payload.ticket_key }}
           phase: dev

--- a/.github/workflows/ferry-iterate.yml
+++ b/.github/workflows/ferry-iterate.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate event envelope
-        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@main
         with:
           payload: ${{ toJson(github.event.client_payload) }}
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run Iterator agent
         id: run-iterator
-        uses: big-emotion/ferry/.github/actions/ferry-run-iterator@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-run-iterator@main
         with:
           payload: ${{ toJson(github.event.client_payload) }}
           jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
@@ -90,7 +90,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Emit audit line
-        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@main
         with:
           ticket: ${{ github.event.client_payload.ticket_key }}
           phase: iterate

--- a/.github/workflows/ferry-refine.yml
+++ b/.github/workflows/ferry-refine.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate event envelope
-        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@main
         with:
           payload: ${{ toJson(github.event.client_payload) }}
 
@@ -50,7 +50,7 @@ jobs:
             | tar -xz -C /usr/local/bin gitleaks
 
       - name: Run Refiner agent
-        uses: big-emotion/ferry/.github/actions/ferry-run-refiner@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-run-refiner@main
         with:
           payload: ${{ toJson(github.event.client_payload) }}
           jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Emit audit line
-        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@main
         with:
           ticket: ${{ github.event.client_payload.ticket_key }}
           phase: refine

--- a/.github/workflows/ferry-review.yml
+++ b/.github/workflows/ferry-review.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate event envelope
-        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@main
         with:
           payload: ${{ toJson(github.event.client_payload) }}
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run Reviewer agent
         id: run-reviewer
-        uses: big-emotion/ferry/.github/actions/ferry-run-reviewer@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-run-reviewer@main
         with:
           payload: ${{ toJson(github.event.client_payload) }}
           jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
@@ -87,7 +87,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Emit audit line
-        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@v0.12.0
+        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@main
         with:
           ticket: ${{ github.event.client_payload.ticket_key }}
           phase: review


### PR DESCRIPTION
Swap @v0.12.0 -> @main across all 4 ferry workflows (ferry-dev, ferry-iterate, ferry-refine, ferry-review) so the agent jobs run against live Ferry main without cutting a release.

Temporary: revert to a tagged release or SHA-pin before merging.